### PR TITLE
Serialize multiple marks on one leaf to html correctly

### DIFF
--- a/packages/slate-plugins/src/__tests__/serializers/serialize-html/htmlSerialize.spec.ts
+++ b/packages/slate-plugins/src/__tests__/serializers/serialize-html/htmlSerialize.spec.ts
@@ -397,3 +397,37 @@ it('serializes with edge case where input is text element', () => {
   const output = 'Test just text.';
   expect(serializeHTMLFromNodes([])(input)).toEqual(output);
 });
+
+it('serialize bold and italic together to html', () => {
+  expect(
+    serializeHTMLFromNodes([BoldPlugin(), ItalicPlugin()])([
+      { text: 'Some paragraph of text with ' },
+      { text: 'bold', bold: true, italic: true },
+      { text: ' part.' },
+    ])
+  ).toEqual('Some paragraph of text with <em><strong>bold</strong></em> part.');
+});
+
+it('serialize bold and superscript together to html', () => {
+  expect(
+    serializeHTMLFromNodes([BoldPlugin(), SuperscriptPlugin()])([
+      { text: 'Some paragraph of text with ' },
+      { text: 'bold', bold: true, superscript: true },
+      { text: ' part.' },
+    ])
+  ).toEqual(
+    'Some paragraph of text with <sup><strong>bold</strong></sup> part.'
+  );
+});
+
+it('serialize bold italic and underline together to html', () => {
+  expect(
+    serializeHTMLFromNodes([BoldPlugin(), ItalicPlugin(), UnderlinePlugin()])([
+      { text: 'Some paragraph of text with ' },
+      { text: 'bold', bold: true, italic: true, underline: true },
+      { text: ' part.' },
+    ])
+  ).toEqual(
+    'Some paragraph of text with <u><em><strong>bold</strong></em></u> part.'
+  );
+});

--- a/packages/slate-plugins/src/serializers/serialize-html/serializeHTMLFromNodes.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/serializeHTMLFromNodes.ts
@@ -41,13 +41,21 @@ const getNode = (elementProps: RenderElementProps, plugins: SlatePlugin[]) => {
 
 const getLeaf = (leafProps: RenderLeafProps, plugins: SlatePlugin[]) => {
   const { children } = leafProps;
-  const leafPlugin = plugins
+  return plugins
     .filter((plugin) => plugin.renderLeaf)
-    .find(({ renderLeaf }) => renderLeaf?.(leafProps) !== children);
-  if (leafPlugin?.renderLeaf) {
-    return renderToStaticMarkup(leafPlugin.renderLeaf(leafProps));
-  }
-  return children;
+    .filter(({ renderLeaf }) => renderLeaf?.(leafProps) !== children)
+    .reduce((result, plugin) => {
+      const newLeafProps = {
+        ...leafProps,
+        children: encodeURIComponent(result),
+      };
+      if (plugin?.renderLeaf) {
+        return decodeURIComponent(
+          renderToStaticMarkup(plugin.renderLeaf(newLeafProps))
+        );
+      }
+      return result;
+    }, children);
 };
 
 /**


### PR DESCRIPTION
## Issue

Fixes: #172 

## What I did

I am no longer taking a first mark plugin and applying it, I am instead taking all mark plugins that apply and apply them one by one. See tests for better explanation.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.