### PR TITLE
add th support for table

### DIFF
--- a/packages/slate-plugins/src/elements/table/components/ToolbarTable.tsx
+++ b/packages/slate-plugins/src/elements/table/components/ToolbarTable.tsx
@@ -10,6 +10,7 @@ export const ToolbarTable = ({
   typeTable = TableType.TABLE,
   typeTr = TableType.ROW,
   typeTd = TableType.CELL,
+  typeTh = TableType.HEAD,
   transform,
   ...props
 }: ToolbarTableProps) => {
@@ -22,6 +23,7 @@ export const ToolbarTable = ({
         typeTable,
         typeTr,
         typeTd,
+        typeTh,
       })}
       {...props}
     />

--- a/packages/slate-plugins/src/elements/table/deserializeTable.ts
+++ b/packages/slate-plugins/src/elements/table/deserializeTable.ts
@@ -6,10 +6,12 @@ export const deserializeTable = ({
   typeTable = TableType.TABLE,
   typeTr = TableType.ROW,
   typeTd = TableType.CELL,
+  typeTh = TableType.HEAD,
 }: TableDeserializeOptions = {}): DeserializeHtml => ({
   element: {
     ...getElementDeserializer(typeTable, { tagNames: ['TABLE'] }),
     ...getElementDeserializer(typeTr, { tagNames: ['TR'] }),
     ...getElementDeserializer(typeTd, { tagNames: ['TD'] }),
+    ...getElementDeserializer(typeTh, { tagNames: ['TH'] }),
   },
 });

--- a/packages/slate-plugins/src/elements/table/queries/isTableCell.ts
+++ b/packages/slate-plugins/src/elements/table/queries/isTableCell.ts
@@ -2,4 +2,4 @@ import { Node } from 'slate';
 import { defaultTableTypes } from '../types';
 
 export const isTableCell = (options = defaultTableTypes) => (n: Node) =>
-  n.type === options.typeTd;
+  n.type === options.typeTd || n.type === options.typeTh;

--- a/packages/slate-plugins/src/elements/table/renderElementTable.tsx
+++ b/packages/slate-plugins/src/elements/table/renderElementTable.tsx
@@ -9,9 +9,11 @@ export const renderElementTable = ({
   typeTable = TableType.TABLE,
   typeTr = TableType.ROW,
   typeTd = TableType.CELL,
+  typeTh = TableType.HEAD,
 }: TableRenderElementOptions = {}) =>
   getRenderElements([
     { component: Table, type: typeTable },
     { component: Row, type: typeTr },
     { component: Cell, type: typeTd },
+    { component: Cell, type: typeTh },
   ]);

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -5,12 +5,14 @@ export enum TableType {
   TABLE = 'table',
   ROW = 'tr',
   CELL = 'td',
+  HEAD = 'th',
 }
 
 export const defaultTableTypes: Required<TableTypeOption> = {
   typeTable: TableType.TABLE,
   typeTr: TableType.ROW,
   typeTd: TableType.CELL,
+  typeTh: TableType.HEAD,
 };
 
 // Data of Element node
@@ -24,6 +26,7 @@ export interface TableTypeOption {
   typeTable?: string;
   typeTr?: string;
   typeTd?: string;
+  typeTh?: string;
 }
 
 // deserialize options

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -48,6 +48,7 @@ export const nodeTypes = {
   typeTable: TableType.TABLE,
   typeTr: TableType.ROW,
   typeTd: TableType.CELL,
+  typeTh: TableType.HEAD,
   typeUl: ListType.UL,
   typeOl: ListType.OL,
   typeLi: ListType.LI,
@@ -767,19 +768,19 @@ const createTable = () => ({
       type: nodeTypes.typeTr,
       children: [
         {
-          type: nodeTypes.typeTd,
+          type: nodeTypes.typeTh,
           children: [{ text: '' }],
         },
         {
-          type: nodeTypes.typeTd,
+          type: nodeTypes.typeTh,
           children: [{ text: 'Human', [nodeTypes.typeBold]: true }],
         },
         {
-          type: nodeTypes.typeTd,
+          type: nodeTypes.typeTh,
           children: [{ text: 'Dog', [nodeTypes.typeBold]: true }],
         },
         {
-          type: nodeTypes.typeTd,
+          type: nodeTypes.typeTh,
           children: [{ text: 'Cat', [nodeTypes.typeBold]: true }],
         },
       ],


### PR DESCRIPTION
## Issue
`<th>` tag are ignored

Fixes:
Fix serialization with html input containing `<th>`  tag

## What I did
Add th type and render same component as td. Style can be applied using data attribute
Update the table initialValue with th type in the first row to check if it was working


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->