### PR TITLE
Fix nested blocks toggling

### DIFF
--- a/packages/slate-plugins/src/common/queries/getSelectionNodesByType.ts
+++ b/packages/slate-plugins/src/common/queries/getSelectionNodesByType.ts
@@ -20,6 +20,7 @@ export const getSelectionNodesByType = (
     match: (n) => {
       return types.includes(n.type as string);
     },
+    at: editor.selection ? Editor.unhangRange(editor, editor.selection) : undefined,
     ...options,
   });
 };

--- a/packages/slate-plugins/src/elements/list/transforms/toggleList.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/toggleList.ts
@@ -33,7 +33,9 @@ export const toggleList = (
 
   if (!isActive) {
     const list = { type: typeList, children: [] };
-    Transforms.wrapNodes(editor, list);
+    Transforms.wrapNodes(editor, list, {
+      at: editor.selection ? Editor.unhangRange(editor, editor.selection) : undefined,
+    });
 
     const nodes = getSelectionNodesArrayByType(editor, typeP);
 


### PR DESCRIPTION
When user selects block content with triple click, selection touches an adjacent block and transforming affects it:
![Screen Recording 2020-07-03 at 14 29 02](https://user-images.githubusercontent.com/6900732/86465212-e4585080-bd39-11ea-9e49-43bfa0fc2b99.gif)

Demo: https://codesandbox.io/s/nifty-frost-6ciri?file=/src/App.tsx
Fixed demo: https://codesandbox.io/s/epic-cartwright-p7xim?file=/src/App.tsx


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->