### PR TITLE
docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,8 +279,9 @@ are on the latest versions (yarn at least v1.3.2).
    _bonus_: use your own fork for this step
 3. `cd slate-plugins`
 4. `yarn`
-5. `yarn test`
-6. `yarn storybook`
+5. `yarn build`
+6. `yarn test` (optional)
+7. `yarn storybook`
 
 ### Working with Storybook
 

--- a/README.md
+++ b/README.md
@@ -192,9 +192,13 @@ Useful scripts include:
 
 > Installs package dependencies
 
+#### `yarn build`
+
+> Build the local packages.
+
 #### `yarn storybook`
 
-> Starts storybook dev
+> Starts storybook dev (after building).
 
 #### `yarn lint`
 


### PR DESCRIPTION
## Issue

Fixes #208 

## What I did

Docs to run `yarn build` before `yarn storybook`

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->