### PR TITLE
Minimize Lodash Footprint

### DIFF
--- a/packages/slate-plugins/src/common/plugins/inline-void/withInlineVoid.ts
+++ b/packages/slate-plugins/src/common/plugins/inline-void/withInlineVoid.ts
@@ -1,5 +1,5 @@
 import { SlatePlugin } from '@udecode/slate-plugins-core';
-import { castArray } from 'lodash';
+import castArray from 'lodash/castArray';
 import { Editor } from 'slate';
 
 export interface WithInlineVoidOptions {

--- a/packages/slate-plugins/src/common/queries/getNodesByType.ts
+++ b/packages/slate-plugins/src/common/queries/getNodesByType.ts
@@ -1,4 +1,4 @@
-import { castArray } from 'lodash';
+import castArray from 'lodash/castArray';
 import { Editor } from 'slate';
 import { EditorNodesOptions } from '../types/Editor.types';
 import { getNodes } from './getNodes';

--- a/packages/slate-plugins/src/common/queries/getPointBefore.ts
+++ b/packages/slate-plugins/src/common/queries/getPointBefore.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-constant-condition */
-import { castArray, map } from 'lodash';
+import castArray from 'lodash/castArray';
+import map from 'lodash/map';
 import { Editor, Location, Path, Point } from 'slate';
 
 export interface BeforeOptions {

--- a/packages/slate-plugins/src/common/transforms/setPropsToNodes.ts
+++ b/packages/slate-plugins/src/common/transforms/setPropsToNodes.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import { Descendant, Node, NodeEntry } from 'slate';
 import { isAncestor, isNodeType } from '../queries';
 import { QueryOptions } from '../types/QueryOptions.types';

--- a/packages/slate-plugins/src/common/transforms/toggleMark.ts
+++ b/packages/slate-plugins/src/common/transforms/toggleMark.ts
@@ -1,4 +1,4 @@
-import { castArray } from 'lodash';
+import castArray from 'lodash/castArray';
 import { Editor } from 'slate';
 import { isMarkActive } from '../queries/isMarkActive';
 

--- a/packages/slate-plugins/src/common/transforms/unwrapNodesByType.ts
+++ b/packages/slate-plugins/src/common/transforms/unwrapNodesByType.ts
@@ -1,4 +1,4 @@
-import { castArray } from 'lodash';
+import castArray from 'lodash/castArray';
 import { Editor, Transforms } from 'slate';
 import { WrapOptions } from '../types/Transforms.types';
 

--- a/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
@@ -1,5 +1,5 @@
 import { DeserializeNode } from '@udecode/slate-plugins-core';
-import { castArray } from 'lodash';
+import castArray from 'lodash/castArray';
 
 export interface GetNodeDeserializerRule {
   /**

--- a/packages/slate-plugins/src/common/utils/getRenderElement.tsx
+++ b/packages/slate-plugins/src/common/utils/getRenderElement.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { pickBy } from 'lodash';
+import pickBy from 'lodash/pickBy';
 import { RenderElementProps } from 'slate-react';
 import { RenderNodeOptions } from '../types/PluginOptions.types';
 

--- a/packages/slate-plugins/src/common/utils/getRenderLeaf.tsx
+++ b/packages/slate-plugins/src/common/utils/getRenderLeaf.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { pickBy } from 'lodash';
+import pickBy from 'lodash/pickBy';
 import { RenderLeafProps } from 'slate-react';
 import { RenderNodeOptions } from '../types/PluginOptions.types';
 

--- a/packages/slate-plugins/src/common/utils/setDefaults.ts
+++ b/packages/slate-plugins/src/common/utils/setDefaults.ts
@@ -1,4 +1,4 @@
-import { defaultsDeep } from 'lodash';
+import defaultsDeep from 'lodash/defaultsDeep';
 
 /**
  * Deep merge the default object properties that are not defined in the destination object.

--- a/packages/slate-plugins/src/handlers/autoformat/withAutoformat.ts
+++ b/packages/slate-plugins/src/handlers/autoformat/withAutoformat.ts
@@ -1,4 +1,4 @@
-import { castArray } from 'lodash';
+import castArray from 'lodash/castArray';
 import { Editor, Range } from 'slate';
 import { getRangeFromBlockStart } from '../../common/queries';
 import { getText } from '../../common/queries/getText';


### PR DESCRIPTION
## Issue
Though for a while Lodash promoted the ability to treeshake automatically, we have found that doesnt seem to work in any of our cases (we've tried the babel/webpack plugin and run into [similar issues as others](https://github.com/lodash/babel-plugin-lodash/issues/236).

Anyways, in our build we noticed slate-plugins was bundling a large part of lodash:
<img width="1029" alt="Screenshot 2020-07-19 09 36 21" src="https://user-images.githubusercontent.com/287640/87880654-a3567200-c9b0-11ea-9bf9-f47d9dcf946c.png">

I'm hoping by using the per method approach, the build process will properly treeshake and reduce that footprint.


## What I did
Replaced all imports of Lodash functions with the named function import



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->