### PR TITLE
Bug/edit links

### DIFF
--- a/packages/slate-plugins/src/elements/link/__tests__/ToolbarLink/onMouseDown-with-url.fixture.tsx
+++ b/packages/slate-plugins/src/elements/link/__tests__/ToolbarLink/onMouseDown-with-url.fixture.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate';
+import { jsx } from '../../../../__test-utils__/jsx';
+
+export const input = ((
+  <editor>
+    <hp>
+      <ha url="https://i.imgur.com/removed.png">
+        <cursor />
+        https://i.imgur.com/removed.png
+      </ha>
+    </hp>
+  </editor>
+) as any) as Editor;
+
+export const output = (
+  <editor>
+    <hp>
+      <ha url="https://i.imgur.com/changed.png">
+        <cursor />
+        https://i.imgur.com/removed.png
+      </ha>
+    </hp>
+  </editor>
+) as any;

--- a/packages/slate-plugins/src/elements/link/__tests__/ToolbarLink/onMouseDown-with-url.spec.tsx
+++ b/packages/slate-plugins/src/elements/link/__tests__/ToolbarLink/onMouseDown-with-url.spec.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import * as SlateReact from 'slate-react';
+import { withToggleType } from '../../../../common/plugins/toggle-type/withToggleType';
+import { pipe } from '../../../../common/utils/pipe';
+import { ELEMENT_H1 } from '../../../heading/defaults';
+import { ToolbarLink } from '../../components/ToolbarLink';
+// import { input, output } from './onMouseDown-with-url.fixture';
+import { input } from './onMouseDown-with-url.fixture';
+
+it('should render', () => {
+  const editor = pipe(input, withToggleType());
+
+  jest.spyOn(SlateReact, 'useSlate').mockReturnValue(editor as any);
+  const prompt = jest
+    .spyOn(window, 'prompt')
+    .mockReturnValue('https://i.imgur.com/changed.png');
+
+  const { getByTestId } = render(<ToolbarLink type={ELEMENT_H1} icon={null} />);
+
+  const element = getByTestId('ToolbarButton');
+  fireEvent.mouseDown(element);
+
+  expect(prompt).toHaveBeenCalledWith(
+    'Enter the URL of the link:',
+    'https://i.imgur.com/removed.png'
+  );
+
+  // expect(editor.children).toEqual(output.children)
+});

--- a/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
+++ b/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useSlate } from 'slate-react';
-import { isNodeTypeIn } from '../../../common/queries';
+import { getAboveByType, isNodeTypeIn } from '../../../common/queries';
 import { setDefaults } from '../../../common/utils/setDefaults';
 import {
   ToolbarButton,
@@ -15,16 +15,19 @@ export const ToolbarLink = ({
   ...props
 }: ToolbarButtonProps & LinkOptions) => {
   const options = setDefaults({ link }, DEFAULTS_LINK);
-
   const editor = useSlate();
-
+  const isLink = isNodeTypeIn(editor, options.link.type);
   return (
     <ToolbarButton
-      active={isNodeTypeIn(editor, options.link.type)}
+      active={isLink}
       onMouseDown={(event) => {
         event.preventDefault();
-
-        const url = window.prompt('Enter the URL of the link:');
+        let prevUrl = '';
+        const linkNode = getAboveByType(editor, options.link.type);
+        if (linkNode) {
+          prevUrl = linkNode[0].url as string;
+        }
+        const url = window.prompt(`Enter the URL of the link:`, prevUrl);
         if (!url) return;
         upsertLinkAtSelection(editor, url, options);
       }}


### PR DESCRIPTION
## Issue

#242 

## What I did

- checked if the actual node has a link as parent
- if so, populate the `window.prompt` with the current link

## Checklist

- [x] The new code matches the existing patterns and styles. (??)
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->