### PR TITLE
Fix dropping element above a list

### DIFF
--- a/packages/slate-plugins/src/common/queries/getPreviousBlockById.spec.ts
+++ b/packages/slate-plugins/src/common/queries/getPreviousBlockById.spec.ts
@@ -27,9 +27,21 @@ const nodesFixtureWithList = [
   },
   {
     children: [
-      {type: 'li', id: '21', children: [{ type: 'p', id: '211', children: [{text: 'hi'}]}]},
-      {type: 'li', id: '22', children: [{ type: 'p', id: '221', children: [{text: 'hi'}]}]},
-      {type: 'li', id: '23', children: [{ type: 'p', id: '231', children: [{text: 'hi'}]}]}
+      {
+        type: 'li',
+        id: '21',
+        children: [{ type: 'p', id: '211', children: [{ text: 'hi' }] }],
+      },
+      {
+        type: 'li',
+        id: '22',
+        children: [{ type: 'p', id: '221', children: [{ text: 'hi' }] }],
+      },
+      {
+        type: 'li',
+        id: '23',
+        children: [{ type: 'p', id: '231', children: [{ text: 'hi' }] }],
+      },
     ],
     id: '2',
     type: 'ul',
@@ -38,8 +50,8 @@ const nodesFixtureWithList = [
     children: [{ text: '' }],
     id: '3',
     type: 'p',
-  }
-]
+  },
+];
 
 describe('when getPreviousNodeById', () => {
   describe('when not first block', () => {
@@ -70,7 +82,9 @@ describe('when getPreviousNodeById', () => {
     it('should return previous block', () => {
       const e = createEditor();
       e.children = nodesFixtureWithList;
-      expect(getPreviousBlockById(e, '2')?.[0]).toEqual(nodesFixtureWithList[0]);
-    })
-  })
+      expect(getPreviousBlockById(e, '2')?.[0]).toEqual(
+        nodesFixtureWithList[0]
+      );
+    });
+  });
 });

--- a/packages/slate-plugins/src/common/queries/getPreviousBlockById.spec.ts
+++ b/packages/slate-plugins/src/common/queries/getPreviousBlockById.spec.ts
@@ -19,6 +19,28 @@ const nodesFixture5 = [
   },
 ];
 
+const nodesFixtureWithList = [
+  {
+    children: [{ text: '' }],
+    id: '1',
+    type: 'p',
+  },
+  {
+    children: [
+      {type: 'li', id: '21', children: [{ type: 'p', id: '211', children: [{text: 'hi'}]}]},
+      {type: 'li', id: '22', children: [{ type: 'p', id: '221', children: [{text: 'hi'}]}]},
+      {type: 'li', id: '23', children: [{ type: 'p', id: '231', children: [{text: 'hi'}]}]}
+    ],
+    id: '2',
+    type: 'ul',
+  },
+  {
+    children: [{ text: '' }],
+    id: '3',
+    type: 'p',
+  }
+]
+
 describe('when getPreviousNodeById', () => {
   describe('when not first block', () => {
     it('should be ', () => {
@@ -43,4 +65,12 @@ describe('when getPreviousNodeById', () => {
       expect(getPreviousBlockById(e, '11')?.[0]).toBeUndefined();
     });
   });
+
+  describe('when list', () => {
+    it('should return previous block', () => {
+      const e = createEditor();
+      e.children = nodesFixtureWithList;
+      expect(getPreviousBlockById(e, '2')?.[0]).toEqual(nodesFixtureWithList[0]);
+    })
+  })
 });

--- a/packages/slate-plugins/src/common/queries/getPreviousBlockById.ts
+++ b/packages/slate-plugins/src/common/queries/getPreviousBlockById.ts
@@ -1,7 +1,7 @@
 import { Editor, Node, NodeEntry } from 'slate';
+import { getBlockPathById } from '../../dnd';
 import { QueryOptions } from '../types/QueryOptions.types';
 import { isNodeType } from './isNodeType';
-import { getBlockPathById } from '../../dnd';
 
 /**
  * Find the block before a block by id.
@@ -12,11 +12,11 @@ export const getPreviousBlockById = (
   id: string,
   query?: QueryOptions
 ): NodeEntry<Node> | undefined => {
-  const path = getBlockPathById(editor, id)
-  if (path) {
-    const prevEntry = Editor.previous(editor, { at: path })
+  const nodePath = getBlockPathById(editor, id);
+  if (nodePath) {
+    const prevEntry = Editor.previous(editor, { at: nodePath });
     if (prevEntry && prevEntry[0].id && Editor.isBlock(editor, prevEntry[0])) {
-      return prevEntry
+      return prevEntry;
     }
   }
   let found = false;

--- a/packages/slate-plugins/src/common/queries/getPreviousBlockById.ts
+++ b/packages/slate-plugins/src/common/queries/getPreviousBlockById.ts
@@ -1,6 +1,7 @@
 import { Editor, Node, NodeEntry } from 'slate';
 import { QueryOptions } from '../types/QueryOptions.types';
 import { isNodeType } from './isNodeType';
+import { getBlockPathById } from '../../dnd';
 
 /**
  * Find the block before a block by id.
@@ -11,6 +12,13 @@ export const getPreviousBlockById = (
   id: string,
   query?: QueryOptions
 ): NodeEntry<Node> | undefined => {
+  const path = getBlockPathById(editor, id)
+  if (path) {
+    const prevEntry = Editor.previous(editor, { at: path })
+    if (prevEntry && prevEntry[0].id && Editor.isBlock(editor, prevEntry[0])) {
+      return prevEntry
+    }
+  }
   let found = false;
   const nodeEntries = [
     ...Editor.nodes(editor, {
@@ -31,11 +39,9 @@ export const getPreviousBlockById = (
       at: [],
     }),
   ];
-
   if (nodeEntries.length) {
     return nodeEntries[0];
   }
-
   if (!found) return;
 
   const firstNodeEntry = [


### PR DESCRIPTION
## Issue
Dropping an element above a list was nesting the dropped element instead of inserting it above the list.
Issue isn't happening on stories, not really sure why, but see added test case to reproduce the issue. Without the newly added code, it fails the test.

## What I did
Used `getBlockPathById` and `Editor.previous` to get the previous block.

## Checklist
- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->