### PR TITLE
Don't show draggable component if readOnly

### DIFF
--- a/packages/slate-plugins/src/dnd/__tests__/selectable.spec.tsx
+++ b/packages/slate-plugins/src/dnd/__tests__/selectable.spec.tsx
@@ -78,4 +78,30 @@ it('should not be draggable if readOnly', () => {
   expect(container.querySelector('.slate-Selectable')).not.toBeInTheDocument();
 });
 
+it('should be draggable in readOnly if allowReadOnly', () => {
+  const editor = jest.fn();
+  jest.spyOn(SlateReact, 'useEditor').mockReturnValue(editor as any);
+  jest.spyOn(SlateReact, 'useReadOnly').mockReturnValue(true);
+  jest.spyOn(ReactEditor, 'findPath').mockReturnValue([0, 0]);
+  const DraggableElement = getSelectableElement({
+    component: DEFAULTS_PARAGRAPH.p.component,
+    allowReadOnly: true
+  });
+  const { container } = render(
+    <DndProvider backend={TestBackend}>
+      <DraggableElement
+        attributes={{} as any}
+        element={{
+          type: DEFAULTS_PARAGRAPH.p.type,
+          children: [{ text: 'test' }],
+        }}
+      >
+        test
+      </DraggableElement>
+    </DndProvider>
+  );
+  expect(container.querySelector('.slate-Selectable')).toBeInTheDocument();
+});
+
+
 it.todo('should be draggable');

--- a/packages/slate-plugins/src/dnd/__tests__/selectable.spec.tsx
+++ b/packages/slate-plugins/src/dnd/__tests__/selectable.spec.tsx
@@ -54,4 +54,28 @@ it('should filter based on level', () => {
   expect(container.querySelector('.slate-Selectable')).not.toBeInTheDocument();
 });
 
+it('should not be draggable if readOnly', () => {
+  const editor = jest.fn();
+  jest.spyOn(SlateReact, 'useEditor').mockReturnValue(editor as any);
+  jest.spyOn(SlateReact, 'useReadOnly').mockReturnValue(true);
+  jest.spyOn(ReactEditor, 'findPath').mockReturnValue([0, 0]);
+  const DraggableElement = getSelectableElement({
+    component: DEFAULTS_PARAGRAPH.p.component,
+  });
+  const { container } = render(
+    <DndProvider backend={TestBackend}>
+      <DraggableElement
+        attributes={{} as any}
+        element={{
+          type: DEFAULTS_PARAGRAPH.p.type,
+          children: [{ text: 'test' }],
+        }}
+      >
+        test
+      </DraggableElement>
+    </DndProvider>
+  );
+  expect(container.querySelector('.slate-Selectable')).not.toBeInTheDocument();
+});
+
 it.todo('should be draggable');

--- a/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
+++ b/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
@@ -19,6 +19,7 @@ export interface GetSelectabelElementOptions {
   styles?: IStyleFunctionOrObject<SelectableStyleProps, SelectableStyles>;
   level?: number;
   filter?: (editor: Editor, path: Path) => boolean;
+  allowReadOnly?: boolean;
 }
 
 export const getSelectableElement = ({
@@ -26,6 +27,7 @@ export const getSelectableElement = ({
   styles,
   level,
   filter,
+  allowReadOnly = false,
 }: GetSelectabelElementOptions) => {
   return forwardRef(
     ({ attributes, element, ...props }: RenderElementProps, ref) => {
@@ -41,7 +43,7 @@ export const getSelectableElement = ({
           (filter && filter(editor, path)),
         [path, editor]
       );
-      if (filteredOut || readOnly) {
+      if (filteredOut || (!allowReadOnly && readOnly)) {
         return (
           <Component attributes={attributes} element={element} {...props} />
         );

--- a/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
+++ b/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
@@ -1,7 +1,12 @@
 import React, { forwardRef, useMemo } from 'react';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Editor, Path } from 'slate';
-import { ReactEditor, RenderElementProps, useEditor } from 'slate-react';
+import {
+  ReactEditor,
+  RenderElementProps,
+  useEditor,
+  useReadOnly,
+} from 'slate-react';
 import { Selectable } from './Selectable';
 import {
   ElementWithId,
@@ -25,6 +30,7 @@ export const getSelectableElement = ({
   return forwardRef(
     ({ attributes, element, ...props }: RenderElementProps, ref) => {
       const editor = useEditor();
+      const readOnly = useReadOnly();
       const path = useMemo(() => ReactEditor.findPath(editor, element), [
         editor,
         element,
@@ -35,7 +41,7 @@ export const getSelectableElement = ({
           (filter && filter(editor, path)),
         [path, editor]
       );
-      if (filteredOut) {
+      if (filteredOut || readOnly) {
         return (
           <Component attributes={attributes} element={element} {...props} />
         );

--- a/stories/examples/dnd.stories.tsx
+++ b/stories/examples/dnd.stories.tsx
@@ -425,6 +425,7 @@ export const Example = () => {
             style={{
               padding: 20,
             }}
+            readOnly={boolean('readOnly', false)}
             plugins={plugins}
             decorate={decorate}
             decorateDeps={[search]}


### PR DESCRIPTION
## Issue
The draggable component was being shown in readOnly mode


## What I did
Return non-draggable component if `readOnly` 


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->