### PR TITLE
Fix null clientOffset

### DIFF
--- a/packages/slate-plugins/src/dnd/utils/getHoverDirection.ts
+++ b/packages/slate-plugins/src/dnd/utils/getHoverDirection.ts
@@ -26,6 +26,7 @@ export const getHoverDirection = (
 
   // Determine mouse position
   const clientOffset = monitor.getClientOffset();
+  if (!clientOffset) return
 
   // Get pixels to the top
   const hoverClientY = (clientOffset as XYCoord).y - hoverBoundingRect.top;

--- a/packages/slate-plugins/src/dnd/utils/getHoverDirection.ts
+++ b/packages/slate-plugins/src/dnd/utils/getHoverDirection.ts
@@ -26,7 +26,7 @@ export const getHoverDirection = (
 
   // Determine mouse position
   const clientOffset = monitor.getClientOffset();
-  if (!clientOffset) return
+  if (!clientOffset) return;
 
   // Get pixels to the top
   const hoverClientY = (clientOffset as XYCoord).y - hoverBoundingRect.top;


### PR DESCRIPTION
## Issue
`getHoverDirection` seems to be triggered in some unrelated mouse events with `clientOffset` as `null` which causes a `Cannot read property 'y' of null` error. 

## What I did
Early return if `clientOffset` is null.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->