### PR TITLE
Fix image in list

### DIFF
--- a/packages/slate-plugins/src/elements/list/__tests__/withList.test.tsx
+++ b/packages/slate-plugins/src/elements/list/__tests__/withList.test.tsx
@@ -1,0 +1,77 @@
+import { createEditor, Transforms } from 'slate';
+import { ReactEditor } from 'slate-react';
+import { DEFAULTS_LIST, withList } from '..';
+import { getAboveByType } from '../../../common/queries/getAboveByType';
+
+const listNodeWithImage = {
+  type: DEFAULTS_LIST.ul.type,
+  children: [
+    {
+      type: DEFAULTS_LIST.li.type,
+      children: [{ type: DEFAULTS_LIST.p.type, children: [{ text: '' }] }],
+    },
+    {
+      type: DEFAULTS_LIST.li.type,
+      children: [
+        { type: DEFAULTS_LIST.p.type, children: [{ text: '' }] },
+        { type: 'image', children: [{ text: '' }] },
+      ],
+    },
+  ],
+};
+describe('withList', () => {
+  it('should insert a new list item when enter is pressed with an image in the current list item', () => {
+    const editor = withList()(createEditor() as ReactEditor);
+    editor.insertNode(listNodeWithImage);
+    const selection = {
+      anchor: { path: [0, 1, 1, 0], offset: 0 },
+      focus: { path: [0, 1, 1, 0], offset: 0 },
+    };
+    Transforms.select(editor, selection);
+    editor.insertBreak();
+    expect((editor.children[0] as { children: any[] }).children.length).toBe(3);
+  });
+  it('should delete the image without deleting the list item when an image is deleted from alist item', () => {
+    const editor = withList()(createEditor() as ReactEditor);
+    editor.insertNode(listNodeWithImage);
+    const selection = {
+      anchor: { path: [0, 1, 1, 0], offset: 0 },
+      focus: { path: [0, 1, 1, 0], offset: 0 },
+    };
+    Transforms.select(editor, selection);
+
+    expect(
+      (editor.children[0] as { children: any[] }).children[1].children.length
+    ).toBe(2);
+    editor.deleteBackward('block');
+    expect((editor.children[0] as { children: any[] }).children.length).toBe(2);
+    expect(
+      (editor.children[0] as { children: any[] }).children[1].children.length
+    ).toBe(1);
+  });
+});
+
+describe('getTypeAboveBylevel()', () => {
+  it('should return a node entry', () => {
+    const editor = withList()(createEditor() as ReactEditor);
+    editor.insertNode(listNodeWithImage);
+    const selection = {
+      anchor: { path: [0, 1, 1, 0], offset: 0 },
+      focus: { path: [0, 1, 1, 0], offset: 0 },
+    };
+    Transforms.select(editor, selection);
+    const nodeEntry = getAboveByType(editor, 'li');
+    expect(nodeEntry).toBeTruthy();
+  });
+  it('should return null', () => {
+    const editor = withList()(createEditor() as ReactEditor);
+    editor.insertNode(listNodeWithImage);
+    const selection = {
+      anchor: { path: [0, 1, 1, 0], offset: 0 },
+      focus: { path: [0, 1, 1, 0], offset: 0 },
+    };
+    Transforms.select(editor, selection);
+    const nodeEntry = getAboveByType(editor, 'ol');
+    expect(nodeEntry).toBeFalsy();
+  });
+});

--- a/packages/slate-plugins/src/elements/list/__tests__/withList.test.tsx
+++ b/packages/slate-plugins/src/elements/list/__tests__/withList.test.tsx
@@ -1,7 +1,7 @@
 import { createEditor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
-import { DEFAULTS_LIST, withList } from '..';
 import { getAboveByType } from '../../../common/queries/getAboveByType';
+import { DEFAULTS_LIST, withList } from '..';
 
 const listNodeWithImage = {
   type: DEFAULTS_LIST.ul.type,

--- a/packages/slate-plugins/src/elements/list/queries/isSelectionInListItem.ts
+++ b/packages/slate-plugins/src/elements/list/queries/isSelectionInListItem.ts
@@ -4,6 +4,7 @@ import { isRangeAtRoot } from '../../../common/queries/isRangeAtRoot';
 import { setDefaults } from '../../../common/utils/setDefaults';
 import { DEFAULTS_LIST } from '../defaults';
 import { ListOptions } from '../types';
+import { getAboveByType } from '../../../common/queries/getAboveByType';
 
 /**
  * Is the selection in li>p.
@@ -20,12 +21,13 @@ export const isSelectionInListItem = (
     isNodeTypeIn(editor, li.type) &&
     !isRangeAtRoot(editor.selection)
   ) {
-    const [paragraphNode, paragraphPath] = Editor.parent(
+    const [, paragraphPath] = Editor.parent(
       editor,
       editor.selection
     );
-    if (paragraphNode.type !== p.type) return;
-    const [listItemNode, listItemPath] = Editor.parent(editor, paragraphPath);
+
+    const [listItemNode, listItemPath] = getAboveByType(editor, li.type) ||  Editor.parent(editor, paragraphPath);
+
     if (listItemNode.type !== li.type) return;
     const [listNode, listPath] = Editor.parent(editor, listItemPath);
 

--- a/packages/slate-plugins/src/elements/list/queries/isSelectionInListItem.ts
+++ b/packages/slate-plugins/src/elements/list/queries/isSelectionInListItem.ts
@@ -1,10 +1,10 @@
 import { Editor } from 'slate';
+import { getAboveByType } from '../../../common/queries/getAboveByType';
 import { isNodeTypeIn } from '../../../common/queries/isNodeTypeIn';
 import { isRangeAtRoot } from '../../../common/queries/isRangeAtRoot';
 import { setDefaults } from '../../../common/utils/setDefaults';
 import { DEFAULTS_LIST } from '../defaults';
 import { ListOptions } from '../types';
-import { getAboveByType } from '../../../common/queries/getAboveByType';
 
 /**
  * Is the selection in li>p.
@@ -14,19 +14,17 @@ export const isSelectionInListItem = (
   editor: Editor,
   options?: ListOptions
 ) => {
-  const { p, li } = setDefaults(options, DEFAULTS_LIST);
+  const { li } = setDefaults(options, DEFAULTS_LIST);
 
   if (
     editor.selection &&
     isNodeTypeIn(editor, li.type) &&
     !isRangeAtRoot(editor.selection)
   ) {
-    const [, paragraphPath] = Editor.parent(
-      editor,
-      editor.selection
-    );
+    const [, paragraphPath] = Editor.parent(editor, editor.selection);
 
-    const [listItemNode, listItemPath] = getAboveByType(editor, li.type) ||  Editor.parent(editor, paragraphPath);
+    const [listItemNode, listItemPath] =
+      getAboveByType(editor, li.type) || Editor.parent(editor, paragraphPath);
 
     if (listItemNode.type !== li.type) return;
     const [listNode, listPath] = Editor.parent(editor, listItemPath);

--- a/packages/slate-plugins/src/elements/list/withList.ts
+++ b/packages/slate-plugins/src/elements/list/withList.ts
@@ -28,12 +28,16 @@ export const withList = (options?: ListOptions) => <T extends ReactEditor>(
     let moved: boolean | undefined;
 
     if (res) {
-      const { listItemNode, listItemPath } = res
+      const { listItemNode, listItemPath } = res;
       if (listItemNode.children.length > 1) {
-        return Transforms.insertNodes(editor, {
-          type: li.type,
-          children: [{ type: p.type, children: [{ text: '' }]}]
-        }, { at: Path.next(listItemPath), select: true });
+        return Transforms.insertNodes(
+          editor,
+          {
+            type: li.type,
+            children: [{ type: p.type, children: [{ text: '' }] }],
+          },
+          { at: Path.next(listItemPath), select: true }
+        );
       }
     }
     if (res && isBlockAboveEmpty(editor)) {
@@ -78,7 +82,10 @@ export const withList = (options?: ListOptions) => <T extends ReactEditor>(
 
     if (res) {
       const { listItemNode } = res;
-      if (listItemNode.children.length > 1 && Range.isCollapsed(editor.selection as Range)) {
+      if (
+        listItemNode.children.length > 1 &&
+        Range.isCollapsed(editor.selection as Range)
+      ) {
         return deleteBackward(unit);
       }
     }

--- a/packages/slate-plugins/src/elements/list/withList.ts
+++ b/packages/slate-plugins/src/elements/list/withList.ts
@@ -31,8 +31,8 @@ export const withList = (options?: ListOptions) => <T extends ReactEditor>(
       const { listItemNode, listItemPath } = res
       if (listItemNode.children.length > 1) {
         return Transforms.insertNodes(editor, {
-          type: DEFAULTS_LIST.li.type,
-          children: [{ type: DEFAULTS_LIST.p.type, children: [{ text: '' }]}]
+          type: li.type,
+          children: [{ type: p.type, children: [{ text: '' }]}]
         }, { at: Path.next(listItemPath), select: true });
       }
     }

--- a/stories/elements/list.stories.tsx
+++ b/stories/elements/list.stories.tsx
@@ -14,11 +14,14 @@ import {
   ToolbarList,
   withList,
   withToggleType,
+  ImagePlugin,
+  withImageUpload, ExitBreakPlugin, SoftBreakPlugin
 } from '@udecode/slate-plugins';
 import { createEditor } from 'slate';
 import { withHistory } from 'slate-history';
 import { Slate, withReact } from 'slate-react';
 import {
+  headingTypes,
   initialValueList,
   options,
   optionsResetBlockTypes,
@@ -37,10 +40,49 @@ const withPlugins = [
   withHistory,
   withToggleType({ defaultType: options.p.type }),
   withList(options),
+  withImageUpload(options)
 ] as const;
 
 export const Example = () => {
-  const plugins: any[] = [ParagraphPlugin(options), HeadingPlugin(options)];
+  const plugins: any[] = [
+    ParagraphPlugin(options),
+    HeadingPlugin(options),
+    ImagePlugin(options),
+    SoftBreakPlugin({
+      rules: [
+        { hotkey: 'shift+enter' },
+        {
+          hotkey: 'enter',
+          query: {
+            allow: [
+              options.code_block.type,
+              options.blockquote.type,
+              options.td.type,
+            ],
+          },
+        },
+      ],
+    }),
+    ExitBreakPlugin({
+      rules: [
+        {
+          hotkey: 'mod+enter',
+        },
+        {
+          hotkey: 'mod+shift+enter',
+          before: true,
+        },
+        {
+          hotkey: 'enter',
+          query: {
+            start: true,
+            end: true,
+            allow: headingTypes,
+          },
+        },
+      ],
+    }),
+  ];
   if (boolean('TodoListPlugin', true)) plugins.push(TodoListPlugin(options));
   if (boolean('ListPlugin', true)) plugins.push(ListPlugin(options));
   if (boolean('ResetBlockTypePlugin', true))


### PR DESCRIPTION
## Issue
After inserting an image within a list, pressing enter removes the image and the list hierarchy is broken.


## What I did
- Allow to press enter on the image and continue with the list: Create a new list item
- Allow to press shift-enter on the image to insert a soft-break: Create a new line without making a new list item.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->