### PR TITLE
Remove default table headers

### DIFF
--- a/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
@@ -24,7 +24,7 @@ export const addColumn = (editor: Editor, options?: TableOptions) => {
 
         Transforms.insertNodes(
           editor,
-          getEmptyCellNode({ ...options, header: !rowIdx }),
+          getEmptyCellNode({ ...options }),
           {
             at: newCellPath,
             select: rowIdx === currentRowIdx,

--- a/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
@@ -22,14 +22,10 @@ export const addColumn = (editor: Editor, options?: TableOptions) => {
       currentTableItem[0].children.forEach((row, rowIdx) => {
         newCellPath[replacePathPos] = rowIdx;
 
-        Transforms.insertNodes(
-          editor,
-          getEmptyCellNode({ ...options }),
-          {
-            at: newCellPath,
-            select: rowIdx === currentRowIdx,
-          }
-        );
+        Transforms.insertNodes(editor, getEmptyCellNode({ ...options }), {
+          at: newCellPath,
+          select: rowIdx === currentRowIdx,
+        });
       });
     }
   }

--- a/packages/slate-plugins/src/elements/table/withTable.ts
+++ b/packages/slate-plugins/src/elements/table/withTable.ts
@@ -7,7 +7,7 @@ import { WithTableOptions } from './types';
 export const withTable = (options?: WithTableOptions) => <T extends Editor>(
   editor: T
 ) => {
-  const { td } = setDefaults(options, DEFAULTS_TABLE);
+  const { td, th } = setDefaults(options, DEFAULTS_TABLE);
 
   const { deleteBackward, deleteForward } = editor;
 
@@ -18,7 +18,7 @@ export const withTable = (options?: WithTableOptions) => <T extends Editor>(
 
     if (isCollapsed(selection)) {
       const [cell] = Editor.nodes(editor, {
-        match: (n) => n.type === td.type,
+        match: (n) => n.type === td.type || n.type === th.type,
       });
 
       if (cell) {

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -888,19 +888,19 @@ const createTable = () => ({
       type: options.tr.type,
       children: [
         {
-          type: options.th.type,
+          type: options.td.type,
           children: [createParagraph('')],
         },
         {
-          type: options.th.type,
+          type: options.td.type,
           children: [createParagraph('Human', options.bold.type)],
         },
         {
-          type: options.th.type,
+          type: options.td.type,
           children: [createParagraph('Dog', options.bold.type)],
         },
         {
-          type: options.th.type,
+          type: options.td.type,
           children: [createParagraph('Cat', options.bold.type)],
         },
       ],


### PR DESCRIPTION
## Issue
- `th` headers were added by default & was not consistent with `insertTable`. 
- `th` cells were being deleted when removing content

![th-default](https://user-images.githubusercontent.com/689720/93690593-01760300-fa8f-11ea-872d-10d31e06a727.gif)

## What I did
- Removed default `th` creation until there's better consistency for adding headers.
- Added `th` cells to `preventDeleteCell`
- Updated story to use table without headers to be more consistent with `insertTable`

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->