### PR TITLE
Fix dropping an item on sibling paths

### DIFF
--- a/packages/slate-plugins/src/dnd/components/Selectable.tsx
+++ b/packages/slate-plugins/src/dnd/components/Selectable.tsx
@@ -31,7 +31,7 @@ const SelectableBase = ({
 
   const { dropLine, dragRef, isDragging } = useDndBlock({
     id: element.id,
-    blockRef,
+    blockRef: rootRef,
   });
 
   const dragWrapperRef = useRef(null);


### PR DESCRIPTION

## Issue
- Dropping an element doesn't work when hovering over the gutter
- Moving an element into a sibling path cause the element to go 1 position above what it should be

## What I did
- Include gutter into droppable zone by using `rootRef` in place of `blockRef`
- Fixes dropping an element on sibling paths by
   1) Ensure that the depth of the tree is maintained when dropping an item on a sibling path
   2) Fix the condition used to check if the source path is before the destination path by accounting for sibling paths.




## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->