### PR TITLE
Add removePreview option to useDndBlock

### DIFF
--- a/packages/slate-plugins/src/dnd/hooks/useDndBlock.ts
+++ b/packages/slate-plugins/src/dnd/hooks/useDndBlock.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { getEmptyImage } from "react-dnd-html5-backend"
 import { ReactEditor, useEditor } from 'slate-react';
 import { ToggleTypeEditor } from '../../common/plugins/toggle-type/withToggleType';
 import { useDragBlock } from './useDragBlock';
@@ -7,9 +8,11 @@ import { useDropBlockOnEditor } from './useDropBlockOnEditor';
 export const useDndBlock = ({
   id,
   blockRef,
+  removePreview,
 }: {
   id: string;
   blockRef: any;
+  removePreview?: boolean;
 }) => {
   const editor = useEditor() as ReactEditor & ToggleTypeEditor;
 
@@ -23,7 +26,12 @@ export const useDndBlock = ({
     setDropLine,
   });
 
-  preview(drop(blockRef));
+  if (removePreview) {
+    drop(blockRef)
+    preview(getEmptyImage(), { captureDraggingState: true })
+  } else {
+    preview(drop(blockRef));
+  }
 
   if (!isOver && dropLine) {
     setDropLine('');


### PR DESCRIPTION
## Issue
I wanted to be able to use the provided `useDndBlock` hook, except remove the drag preview in order to use a custom drag image.

## What I did
Added an optional boolean argument `removePreview` to the useDndBlock hook.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->