### PR TITLE
IMP(withlink): allow custom range before options

### DIFF
--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -2,6 +2,7 @@ import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
+import { RangeBeforeOptions } from '../../common/queries/getRangeBefore';
 import {
   RenderNodeOptions,
   RenderNodePropsOptions,
@@ -47,6 +48,10 @@ export type LinkPluginOptionsValues = RenderNodeOptions &
      * Callback to validate an url.
      */
     isUrl?: (text: string) => boolean;
+    /**
+     * Allow custom config for rangeBeforeOptions.
+     */
+    rangeBeforeOptions?: RangeBeforeOptions;
   };
 export type LinkPluginOptionsKeys = keyof LinkPluginOptionsValues;
 export type LinkPluginOptions<

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -48,10 +48,6 @@ export type LinkPluginOptionsValues = RenderNodeOptions &
      * Callback to validate an url.
      */
     isUrl?: (text: string) => boolean;
-    /**
-     * Allow custom config for rangeBeforeOptions.
-     */
-    rangeBeforeOptions?: RangeBeforeOptions;
   };
 export type LinkPluginOptionsKeys = keyof LinkPluginOptionsValues;
 export type LinkPluginOptions<
@@ -67,7 +63,12 @@ export interface LinkRenderElementOptions
 export interface LinkDeserializeOptions
   extends LinkPluginOptions<'type' | 'rootProps'> {}
 
-export interface WithLinkOptions extends LinkPluginOptions<'type' | 'isUrl'> {}
+export interface WithLinkOptions extends LinkPluginOptions<'type' | 'isUrl'> {
+   /**
+     * Allow custom config for rangeBeforeOptions.
+     */
+    rangeBeforeOptions?: RangeBeforeOptions;
+}
 
 export interface LinkOptions extends LinkPluginOptions<'type'> {}
 

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -64,10 +64,10 @@ export interface LinkDeserializeOptions
   extends LinkPluginOptions<'type' | 'rootProps'> {}
 
 export interface WithLinkOptions extends LinkPluginOptions<'type' | 'isUrl'> {
-   /**
-     * Allow custom config for rangeBeforeOptions.
-     */
-    rangeBeforeOptions?: RangeBeforeOptions;
+  /**
+   * Allow custom config for rangeBeforeOptions.
+   */
+  rangeBeforeOptions?: RangeBeforeOptions;
 }
 
 export interface LinkOptions extends LinkPluginOptions<'type'> {}

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -1,6 +1,9 @@
 import { Editor, Range } from 'slate';
 import { ReactEditor } from 'slate-react';
-import { getRangeBefore } from '../../common/queries/getRangeBefore';
+import {
+  getRangeBefore,
+  RangeBeforeOptions,
+} from '../../common/queries/getRangeBefore';
 import { getRangeFromBlockStart } from '../../common/queries/getRangeFromBlockStart';
 import { getText } from '../../common/queries/getText';
 import { isCollapsed } from '../../common/queries/isCollapsed';
@@ -46,9 +49,10 @@ const upsertLink = (
  * Paste a string inside a link element will edit its children text but not its url.
  *
  */
-export const withLink = (options?: WithLinkOptions) => <T extends ReactEditor>(
-  editor: T
-) => {
+export const withLink = (
+  options?: WithLinkOptions,
+  rangeBeforeOptions?: RangeBeforeOptions
+) => <T extends ReactEditor>(editor: T) => {
   const { link, isUrl } = setDefaults(options, {
     ...DEFAULTS_LINK,
     isUrl: isUrlProtocol,

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -41,6 +41,10 @@ const upsertLink = (
 };
 
 /**
+ * To used when call withLink with rangeBeforeOptions. Default value for options is undefined
+ */
+export const DEFAULT_WITH_LINK_OPTIONS = undefined;
+/**
  * Insert space after a url to wrap a link.
  * Lookup from the block start to the cursor to check if there is an url.
  * If not found, lookup before the cursor for a space character to check the url.

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import { Editor, Range } from 'slate';
 import { ReactEditor } from 'slate-react';
 import {
@@ -41,10 +42,6 @@ const upsertLink = (
 };
 
 /**
- * To used when call withLink with rangeBeforeOptions. Default value for options is undefined
- */
-export const DEFAULT_WITH_LINK_OPTIONS = undefined;
-/**
  * Insert space after a url to wrap a link.
  * Lookup from the block start to the cursor to check if there is an url.
  * If not found, lookup before the cursor for a space character to check the url.
@@ -53,10 +50,9 @@ export const DEFAULT_WITH_LINK_OPTIONS = undefined;
  * Paste a string inside a link element will edit its children text but not its url.
  *
  */
-export const withLink = (
-  options?: WithLinkOptions,
-  rangeBeforeOptions?: RangeBeforeOptions
-) => <T extends ReactEditor>(editor: T) => {
+export const withLink = (options?: WithLinkOptions) => <T extends ReactEditor>(
+  editor: T
+) => {
   const { link, isUrl } = setDefaults(options, {
     ...DEFAULTS_LINK,
     isUrl: isUrlProtocol,
@@ -87,13 +83,9 @@ export const withLink = (
 
       const rangeOptions: RangeBeforeOptions = {
         ...DEFAULT_RANGE_BEFORE_OPTIONS,
-        ...rangeBeforeOptions,
-      }
-      const beforeWordRange = getRangeBefore(
-        editor,
-        selection,
-        rangeOptions
-      );
+        ...get(options, 'rangeBeforeOptions', {}),
+      };
+      const beforeWordRange = getRangeBefore(editor, selection, rangeOptions);
 
       if (beforeWordRange) {
         const beforeWordText = getText(editor, beforeWordRange);

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { Editor, Range } from 'slate';
 import { ReactEditor } from 'slate-react';
 import {

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -61,6 +61,12 @@ export const withLink = (
   const { insertData, insertText } = editor;
 
   editor.insertText = (text) => {
+    const DEFAULT_RANGE_BEFORE_OPTIONS: RangeBeforeOptions = {
+      matchString: ' ',
+      skipInvalid: true,
+      afterMatch: true,
+      multiPaths: true,
+    };
     if (text === ' ' && isCollapsed(editor.selection)) {
       const selection = editor.selection as Range;
 
@@ -75,12 +81,11 @@ export const withLink = (
         return insertText(text);
       }
 
-      const beforeWordRange = getRangeBefore(editor, selection, {
-        matchString: ' ',
-        skipInvalid: true,
-        afterMatch: true,
-        multiPaths: true,
-      });
+      const beforeWordRange = getRangeBefore(
+        editor,
+        selection,
+        DEFAULT_RANGE_BEFORE_OPTIONS
+      );
 
       if (beforeWordRange) {
         const beforeWordText = getText(editor, beforeWordRange);

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -81,10 +81,14 @@ export const withLink = (
         return insertText(text);
       }
 
+      const rangeOptions: RangeBeforeOptions = {
+        ...DEFAULT_RANGE_BEFORE_OPTIONS,
+        ...rangeBeforeOptions,
+      }
       const beforeWordRange = getRangeBefore(
         editor,
         selection,
-        DEFAULT_RANGE_BEFORE_OPTIONS
+        rangeOptions
       );
 
       if (beforeWordRange) {


### PR DESCRIPTION
## Issue

I can't configure options used to get beforeWordRange

## What I did

add new params in withLink function. I also keep default configuration option
## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->