### PR TITLE
Don't delete table cells. Closes #284

### DIFF
--- a/packages/slate-plugins/src/elements/table/__tests__/withTable.spec.ts
+++ b/packages/slate-plugins/src/elements/table/__tests__/withTable.spec.ts
@@ -1,0 +1,57 @@
+
+import { createEditor } from 'slate';
+import { withTable, getEmptyTableNode } from '..'
+
+const content = [
+  { type: 'p', children: [{ text: 'A' }]},
+  { type: 'table', children: [
+    { type: 'tr', children: [
+      { type: 'td', children: [{ text: 'A1' }] },
+      { type: 'td', children: [{ text: 'B1' }] }
+    ]},
+    { type: 'tr', children: [
+      { type: 'td', children: [{ text: 'A2' }] },
+      { type: 'td', children: [{ text: 'B2' }] }
+    ]}
+  ]},
+  { type: 'p', children: [{ text: 'B'}]}
+] as any
+
+const out = [...content]
+out[1].children[0].children[0].children[0].text = ''
+out[1].children[0].children[1].children[0].text = ''
+
+describe('withTable', () => {
+  it('should prevent cell deletions on deleteBackward from outside the table', () => {
+    const editor = withTable()(createEditor())
+    editor.children = content
+    editor.selection = {
+      anchor: { path: [2, 0], offset: 0 },
+      focus: { path: [2, 0], offset: 0 },
+    };
+    editor.deleteBackward('character')
+    expect(editor.children).toEqual(content)
+  })
+  it('should prevent cell deletions on deleteForward from outside the table', () => {
+    const editor = withTable()(createEditor())
+    editor.children = content
+    editor.selection = {
+      anchor: { path: [0, 0], offset: 1 },
+      focus: { path: [0, 0], offset: 1 },
+    };
+    editor.deleteForward('character')
+    expect(editor.children).toEqual(content)
+  })
+  it('should prevent cell deletions when selecting multiple cells', () => {
+    const editor = withTable()(createEditor())
+    editor.children = content
+    editor.selection = {
+      anchor: { path: [1, 0, 0, 0], offset: 0 },
+      focus: { path: [1, 0, 1, 0], offset: 0 },
+    };
+    editor.deleteFragment()
+    expect(editor.children).toEqual(out)
+  })
+  it.todo('should prevent cell deletions on insertText')
+  it.todo('should prevent cell deletions on delete within a cell')
+})

--- a/packages/slate-plugins/src/elements/table/__tests__/withTable.spec.ts
+++ b/packages/slate-plugins/src/elements/table/__tests__/withTable.spec.ts
@@ -1,57 +1,65 @@
-
 import { createEditor } from 'slate';
-import { withTable, getEmptyTableNode } from '..'
+import { withTable } from '..';
 
 const content = [
-  { type: 'p', children: [{ text: 'A' }]},
-  { type: 'table', children: [
-    { type: 'tr', children: [
-      { type: 'td', children: [{ text: 'A1' }] },
-      { type: 'td', children: [{ text: 'B1' }] }
-    ]},
-    { type: 'tr', children: [
-      { type: 'td', children: [{ text: 'A2' }] },
-      { type: 'td', children: [{ text: 'B2' }] }
-    ]}
-  ]},
-  { type: 'p', children: [{ text: 'B'}]}
-] as any
+  { type: 'p', children: [{ text: 'A' }] },
+  {
+    type: 'table',
+    children: [
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: 'A1' }] },
+          { type: 'td', children: [{ text: 'B1' }] },
+        ],
+      },
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: 'A2' }] },
+          { type: 'td', children: [{ text: 'B2' }] },
+        ],
+      },
+    ],
+  },
+  { type: 'p', children: [{ text: 'B' }] },
+] as any;
 
-const out = [...content]
-out[1].children[0].children[0].children[0].text = ''
-out[1].children[0].children[1].children[0].text = ''
+const out = [...content];
+out[1].children[0].children[0].children[0].text = '';
+out[1].children[0].children[1].children[0].text = '';
 
 describe('withTable', () => {
   it('should prevent cell deletions on deleteBackward from outside the table', () => {
-    const editor = withTable()(createEditor())
-    editor.children = content
+    const editor = withTable()(createEditor());
+    editor.children = content;
     editor.selection = {
       anchor: { path: [2, 0], offset: 0 },
       focus: { path: [2, 0], offset: 0 },
     };
-    editor.deleteBackward('character')
-    expect(editor.children).toEqual(content)
-  })
+    editor.deleteBackward('character');
+    expect(editor.children).toEqual(content);
+  });
   it('should prevent cell deletions on deleteForward from outside the table', () => {
-    const editor = withTable()(createEditor())
-    editor.children = content
+    const editor = withTable()(createEditor());
+    editor.children = content;
     editor.selection = {
       anchor: { path: [0, 0], offset: 1 },
       focus: { path: [0, 0], offset: 1 },
     };
-    editor.deleteForward('character')
-    expect(editor.children).toEqual(content)
-  })
+    editor.deleteForward('character');
+    expect(editor.children).toEqual(content);
+  });
   it('should prevent cell deletions when selecting multiple cells', () => {
-    const editor = withTable()(createEditor())
-    editor.children = content
+    const editor = withTable()(createEditor());
+    editor.children = content;
     editor.selection = {
       anchor: { path: [1, 0, 0, 0], offset: 0 },
       focus: { path: [1, 0, 1, 0], offset: 0 },
     };
-    editor.deleteFragment()
-    expect(editor.children).toEqual(out)
-  })
-  it.todo('should prevent cell deletions on insertText')
-  it.todo('should prevent cell deletions on delete within a cell')
-})
+    editor.deleteFragment();
+    expect(editor.children).toEqual(out);
+  });
+  it.todo('should prevent cell deletions on insertText');
+  it.todo('should prevent cell deletions on delete within a cell');
+});

--- a/packages/slate-plugins/src/elements/table/withTable.ts
+++ b/packages/slate-plugins/src/elements/table/withTable.ts
@@ -11,7 +11,7 @@ export const withTable = (options?: WithTableOptions) => <T extends Editor>(
   const matchCells = (node: Node) =>
     node.type === td.type || node.type === th.type;
 
-  const { deleteBackward, deleteForward, deleteFragment } = editor;
+  const { deleteBackward, deleteForward, deleteFragment, insertText } = editor;
 
   const preventDeleteCell = (
     operation: any,
@@ -72,6 +72,20 @@ export const withTable = (options?: WithTableOptions) => <T extends Editor>(
       return;
     }
     deleteFragment();
+  };
+
+  editor.insertText = (text) => {
+    const { selection } = editor;
+    // Collapse selection if multiple cells are selected to avoid breaking the table
+    if (!isCollapsed(selection)) {
+      const [cell] = Editor.nodes(editor, { match: matchCells });
+      if (cell) {
+        Transforms.collapse(editor, { edge: 'end' });
+        insertText(text);
+        return;
+      }
+    }
+    insertText(text);
   };
 
   // prevent deleting cells with deleteBackward


### PR DESCRIPTION
## Issue
#284 


## What I did
- Don't delete a cell if deleting forward/backward next to a table by checking the location next to the current selection
- Don't delete cells if partially selecting a table by checking if a selection starts or ends within a table cell
- Don't delete cells on `insertText` if multiple cells are selected

## TODO:
- [x] Add tests
- Delete content on `deleteFragment`. Currently, it's just doing an early return but we probably want to allow clearing the table contents without deleting the cells. @zbeyens any thoughts on the best way to achieve that?

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->