### PR TITLE
Fix deletions within a cell

### DIFF
--- a/packages/slate-plugins/src/elements/table/__tests__/fixtures.ts
+++ b/packages/slate-plugins/src/elements/table/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-export const content = [
+export const content = Object.freeze([
   { type: 'p', children: [{ text: 'A' }] },
   {
     type: 'table',
@@ -20,9 +20,9 @@ export const content = [
     ],
   },
   { type: 'p', children: [{ text: 'B' }] },
-] as any;
+]) as any;
 
-export const out = [
+export const out = Object.freeze([
   { type: 'p', children: [{ text: 'A' }] },
   {
     type: 'table',
@@ -44,9 +44,9 @@ export const out = [
     ],
   },
   { type: 'p', children: [{ text: 'B' }] },
-];
+]);
 
-export const output2 = [
+export const output2 = Object.freeze([
   { type: 'p', children: [{ text: 'A' }] },
   {
     type: 'table',
@@ -68,4 +68,4 @@ export const output2 = [
     ],
   },
   { type: 'p', children: [{ text: 'B' }] },
-];
+]);

--- a/packages/slate-plugins/src/elements/table/__tests__/fixtures.ts
+++ b/packages/slate-plugins/src/elements/table/__tests__/fixtures.ts
@@ -1,0 +1,71 @@
+export const content = [
+  { type: 'p', children: [{ text: 'A' }] },
+  {
+    type: 'table',
+    children: [
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: 'A1' }] },
+          { type: 'td', children: [{ text: 'B1' }] },
+        ],
+      },
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: 'A2' }] },
+          { type: 'td', children: [{ text: 'B2' }] },
+        ],
+      },
+    ],
+  },
+  { type: 'p', children: [{ text: 'B' }] },
+] as any;
+
+export const out = [
+  { type: 'p', children: [{ text: 'A' }] },
+  {
+    type: 'table',
+    children: [
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: '' }] },
+          { type: 'td', children: [{ text: '' }] },
+        ],
+      },
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: 'A2' }] },
+          { type: 'td', children: [{ text: 'B2' }] },
+        ],
+      },
+    ],
+  },
+  { type: 'p', children: [{ text: 'B' }] },
+];
+
+export const output2 = [
+  { type: 'p', children: [{ text: 'A' }] },
+  {
+    type: 'table',
+    children: [
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: '1' }] },
+          { type: 'td', children: [{ text: 'B1' }] },
+        ],
+      },
+      {
+        type: 'tr',
+        children: [
+          { type: 'td', children: [{ text: 'A2' }] },
+          { type: 'td', children: [{ text: 'B2' }] },
+        ],
+      },
+    ],
+  },
+  { type: 'p', children: [{ text: 'B' }] },
+];

--- a/packages/slate-plugins/src/elements/table/__tests__/withTable.spec.ts
+++ b/packages/slate-plugins/src/elements/table/__tests__/withTable.spec.ts
@@ -1,33 +1,6 @@
 import { createEditor } from 'slate';
 import { withTable } from '..';
-
-const content = [
-  { type: 'p', children: [{ text: 'A' }] },
-  {
-    type: 'table',
-    children: [
-      {
-        type: 'tr',
-        children: [
-          { type: 'td', children: [{ text: 'A1' }] },
-          { type: 'td', children: [{ text: 'B1' }] },
-        ],
-      },
-      {
-        type: 'tr',
-        children: [
-          { type: 'td', children: [{ text: 'A2' }] },
-          { type: 'td', children: [{ text: 'B2' }] },
-        ],
-      },
-    ],
-  },
-  { type: 'p', children: [{ text: 'B' }] },
-] as any;
-
-const out = [...content];
-out[1].children[0].children[0].children[0].text = '';
-out[1].children[0].children[1].children[0].text = '';
+import { content, out, output2 } from './fixtures';
 
 describe('withTable', () => {
   it('should prevent cell deletions on deleteBackward from outside the table', () => {
@@ -60,6 +33,16 @@ describe('withTable', () => {
     editor.deleteFragment();
     expect(editor.children).toEqual(out);
   });
+  it('should allow deletions within a cell without deleting the cell', () => {
+    const editor = withTable()(createEditor());
+    editor.children = content;
+    editor.selection = {
+      anchor: { path: [1, 0, 0, 0], offset: 1 },
+      focus: { path: [1, 0, 0, 0], offset: 1 },
+    };
+    editor.deleteBackward('character');
+    editor.deleteBackward('character');
+    expect(editor.children).toEqual(output2);
+  });
   it.todo('should prevent cell deletions on insertText');
-  it.todo('should prevent cell deletions on delete within a cell');
 });

--- a/packages/slate-plugins/src/elements/table/withTable.ts
+++ b/packages/slate-plugins/src/elements/table/withTable.ts
@@ -19,29 +19,27 @@ export const withTable = (options?: WithTableOptions) => <T extends Editor>(
     nextPoint: any
   ) => (unit: any) => {
     const { selection } = editor;
-    // Prevent deletions within a cell
+
     if (isCollapsed(selection)) {
+      // Prevent deletions within a cell
       const [cell] = Editor.nodes(editor, {
         match: matchCells,
       });
+      const next = nextPoint(editor, selection, { unit });
+      // Prevent deleting cell when selection is before or after a table
+      const [nextCell] = Editor.nodes(editor, {
+        match: matchCells,
+        at: next,
+      });
 
-      if (cell) {
-        const [, cellPath] = cell;
+      if (cell || nextCell) {
+        const [, cellPath] = cell || nextCell;
         const start = pointCallback(editor, cellPath);
 
         if (selection && Point.equals(selection.anchor, start)) {
           return;
         }
       }
-    }
-    // Prevent deleting cell when selection is before or after a table
-    const next = nextPoint(editor, selection, { unit });
-    const [cell] = Editor.nodes(editor, {
-      match: matchCells,
-      at: next,
-    });
-    if (cell) {
-      return;
     }
 
     operation(unit);

--- a/packages/slate-plugins/src/elements/table/withTable.ts
+++ b/packages/slate-plugins/src/elements/table/withTable.ts
@@ -21,24 +21,25 @@ export const withTable = (options?: WithTableOptions) => <T extends Editor>(
     const { selection } = editor;
 
     if (isCollapsed(selection)) {
-      // Prevent deletions within a cell
       const [cell] = Editor.nodes(editor, {
         match: matchCells,
       });
-      const next = nextPoint(editor, selection, { unit });
-      // Prevent deleting cell when selection is before or after a table
-      const [nextCell] = Editor.nodes(editor, {
-        match: matchCells,
-        at: next,
-      });
-
-      if (cell || nextCell) {
-        const [, cellPath] = cell || nextCell;
+      if (cell) {
+        // Prevent deletions within a cell
+        const [, cellPath] = cell;
         const start = pointCallback(editor, cellPath);
 
         if (selection && Point.equals(selection.anchor, start)) {
           return;
         }
+      } else {
+        // Prevent deleting cell when selection is before or after a table
+        const next = nextPoint(editor, selection, { unit });
+        const [nextCell] = Editor.nodes(editor, {
+          match: matchCells,
+          at: next,
+        });
+        if (nextCell) return;
       }
     }
 


### PR DESCRIPTION
## Issue
My previous PR #298 introduced a bug that was preventing to do valid deletions within a cell.


## What I did
- Fixed the bug by using the same logic used for preventing cell deletions when the selection is inside the cell
- Added a test to check for valid deletions within a cell while preventing deleting the cell
- Moved fixtures into its own file

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->