### PR TITLE
Imp/use hotkey types

### DIFF
--- a/packages/slate-plugins/src/common/utils/onKeyDownType.ts
+++ b/packages/slate-plugins/src/common/utils/onKeyDownType.ts
@@ -1,0 +1,43 @@
+import isHotkey from 'is-hotkey';
+import { Editor, Transforms } from 'slate';
+import get from 'lodash/get';
+import { ELEMENT_BLOCKQUOTE, ELEMENT_PARAGRAPH } from "@udecode/slate-plugins";
+import { getAboveByType } from '../queries/getAboveByType';
+export interface TypeOnKeyDownOptions {
+  /**
+   * Key of the mark
+   */
+  type: string;
+
+  /**
+   * Hotkey to toggle the mark
+   */
+  hotkey?: string;
+}
+
+/**
+ * Get `onKeyDown` handler if there is a hotkey defined.
+ */
+export const onKeyDownType = ({ type, hotkey }: TypeOnKeyDownOptions) =>
+  hotkey
+    ? (e: any, editor: Editor) => {
+      if (isHotkey(hotkey, e)) {
+        e.preventDefault();
+        const t = getAboveByType(editor, ELEMENT_BLOCKQUOTE)
+        const above = Editor.above(editor);
+        if (above) {
+          const [node, _] = above;
+          const nodeType = get(node, 'type');
+          if (nodeType === type) {
+            Transforms.setNodes(editor, {
+              type: ELEMENT_PARAGRAPH
+            });
+          } else {
+            Transforms.setNodes(editor, {
+              type
+            });
+          }
+        }
+      }
+    }
+    : undefined;

--- a/packages/slate-plugins/src/common/utils/onKeyDownType.ts
+++ b/packages/slate-plugins/src/common/utils/onKeyDownType.ts
@@ -1,8 +1,8 @@
 import isHotkey from 'is-hotkey';
-import { Editor, Transforms } from 'slate';
 import get from 'lodash/get';
-import { ELEMENT_BLOCKQUOTE, ELEMENT_PARAGRAPH } from "@udecode/slate-plugins";
-import { getAboveByType } from '../queries/getAboveByType';
+import { Editor, Transforms } from 'slate';
+import { ELEMENT_PARAGRAPH } from '../../elements/paragraph/defaults';
+
 export interface TypeOnKeyDownOptions {
   /**
    * Key of the mark
@@ -21,23 +21,22 @@ export interface TypeOnKeyDownOptions {
 export const onKeyDownType = ({ type, hotkey }: TypeOnKeyDownOptions) =>
   hotkey
     ? (e: any, editor: Editor) => {
-      if (isHotkey(hotkey, e)) {
-        e.preventDefault();
-        const t = getAboveByType(editor, ELEMENT_BLOCKQUOTE)
-        const above = Editor.above(editor);
-        if (above) {
-          const [node, _] = above;
-          const nodeType = get(node, 'type');
-          if (nodeType === type) {
-            Transforms.setNodes(editor, {
-              type: ELEMENT_PARAGRAPH
-            });
-          } else {
-            Transforms.setNodes(editor, {
-              type
-            });
+        if (isHotkey(hotkey, e)) {
+          e.preventDefault();
+          const above = Editor.above(editor);
+          if (above) {
+            const [node] = above;
+            const nodeType = get(node, 'type');
+            if (nodeType === type) {
+              Transforms.setNodes(editor, {
+                type: ELEMENT_PARAGRAPH,
+              });
+            } else {
+              Transforms.setNodes(editor, {
+                type,
+              });
+            }
           }
         }
       }
-    }
     : undefined;

--- a/packages/slate-plugins/src/common/utils/onKeyDownTypeDefault.ts
+++ b/packages/slate-plugins/src/common/utils/onKeyDownTypeDefault.ts
@@ -1,0 +1,18 @@
+import { onKeyDownType } from './onKeyDownType';
+import { setDefaults } from './setDefaults';
+
+/**
+ * Get `onKeyDown` handler for mark with default options.
+ */
+export const onKeyDownTypeDefault = <Key extends string>({
+  key,
+  defaultOptions,
+  options,
+}: {
+  key: Key;
+  defaultOptions: Record<Key, any>;
+  options?: any;
+}) => {
+  const keyOptions = setDefaults(options, defaultOptions)[key];
+  return onKeyDownType(keyOptions);
+};

--- a/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
+++ b/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
@@ -2,6 +2,8 @@ import { SlatePlugin } from '@udecode/slate-plugins-core';
 import { deserializeBlockquote } from './deserializeBlockquote';
 import { renderElementBlockquote } from './renderElementBlockquote';
 import { BlockquotePluginOptions } from './types';
+import { onKeyDownTypeDefault } from '../../common/utils/onKeyDownTypeDefault';
+import { DEFAULTS_BLOCKQUOTE } from './defaults';
 
 /**
  * Enables support for block quotes, useful for
@@ -12,4 +14,9 @@ export const BlockquotePlugin = (
 ): SlatePlugin => ({
   renderElement: renderElementBlockquote(options),
   deserialize: deserializeBlockquote(options),
+  onKeyDown: onKeyDownTypeDefault({
+    key: 'blockquote',
+    defaultOptions: DEFAULTS_BLOCKQUOTE,
+    options,
+  }),
 });

--- a/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
+++ b/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
@@ -1,9 +1,9 @@
 import { SlatePlugin } from '@udecode/slate-plugins-core';
+import { onKeyDownTypeDefault } from '../../common/utils/onKeyDownTypeDefault';
+import { DEFAULTS_BLOCKQUOTE } from './defaults';
 import { deserializeBlockquote } from './deserializeBlockquote';
 import { renderElementBlockquote } from './renderElementBlockquote';
 import { BlockquotePluginOptions } from './types';
-import { onKeyDownTypeDefault } from '../../common/utils/onKeyDownTypeDefault';
-import { DEFAULTS_BLOCKQUOTE } from './defaults';
 
 /**
  * Enables support for block quotes, useful for

--- a/packages/slate-plugins/src/elements/blockquote/defaults.ts
+++ b/packages/slate-plugins/src/elements/blockquote/defaults.ts
@@ -1,15 +1,17 @@
 import { BlockquoteElement } from './components/BlockquoteElement';
 import { BlockquoteKeyOption, BlockquotePluginOptionsValues } from './types';
+import { TypeOnKeyDownOptions } from '../../common/utils/onKeyDownType';
 
 export const ELEMENT_BLOCKQUOTE = 'blockquote';
 
 export const DEFAULTS_BLOCKQUOTE: Record<
   BlockquoteKeyOption,
-  Required<BlockquotePluginOptionsValues>
+  Required<BlockquotePluginOptionsValues> & TypeOnKeyDownOptions
 > = {
   blockquote: {
     component: BlockquoteElement,
     type: ELEMENT_BLOCKQUOTE,
+    hotkey: 'mod+shift+.',
     rootProps: {
       className: 'slate-blockquote',
       as: 'blockquote',

--- a/packages/slate-plugins/src/elements/blockquote/defaults.ts
+++ b/packages/slate-plugins/src/elements/blockquote/defaults.ts
@@ -1,6 +1,6 @@
+import { TypeOnKeyDownOptions } from '../../common/utils/onKeyDownType';
 import { BlockquoteElement } from './components/BlockquoteElement';
 import { BlockquoteKeyOption, BlockquotePluginOptionsValues } from './types';
-import { TypeOnKeyDownOptions } from '../../common/utils/onKeyDownType';
 
 export const ELEMENT_BLOCKQUOTE = 'blockquote';
 


### PR DESCRIPTION
## Issue

Cannot use hotKey with Types

## What I did

First pr to handle blockquote with hotkey

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->