### PR TITLE
fix-todo-list

### DIFF
--- a/packages/slate-plugins/src/elements/todo-list/components/TodoListElement.styles.ts
+++ b/packages/slate-plugins/src/elements/todo-list/components/TodoListElement.styles.ts
@@ -18,6 +18,7 @@ export const getTodoListElementStyles = ({
       rootClassName,
     ],
     checkboxWrapper: {
+      userSelect: 'none',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',

--- a/packages/slate-plugins/src/elements/todo-list/components/TodoListElement.tsx
+++ b/packages/slate-plugins/src/elements/todo-list/components/TodoListElement.tsx
@@ -42,7 +42,7 @@ export const TodoListElementBase = ({
           data-testid="TodoListElementCheckbox"
           className={classNames.checkbox}
           type="checkbox"
-          checked={checked}
+          checked={!!checked}
           onChange={(e) => {
             const path = ReactEditor.findPath(editor, element);
 

--- a/packages/slate-plugins/src/elements/todo-list/types.ts
+++ b/packages/slate-plugins/src/elements/todo-list/types.ts
@@ -14,7 +14,7 @@ import {
 
 // Data of Element node
 export interface TodoListNodeData {
-  checked: boolean;
+  checked?: boolean;
 }
 // Element node
 export interface TodoListNode extends Element, TodoListNodeData {}

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -45,7 +45,7 @@ export const autoformatRules: AutoformatRule[] = [
   },
   {
     type: options.li.type,
-    markup: ['*', '-', '+'],
+    markup: ['*', '-'],
     preFormat,
     format: (editor) => {
       toggleList(editor, { ...options, typeList: options.ul.type });
@@ -58,6 +58,10 @@ export const autoformatRules: AutoformatRule[] = [
     format: (editor) => {
       toggleList(editor, { ...options, typeList: options.ol.type });
     },
+  },
+  {
+    type: options.todo_li.type,
+    markup: ['[]'],
   },
   {
     type: options.blockquote.type,


### PR DESCRIPTION
### Bug Fixes
- `todo-list`:
  - use `user-select: none` in the checkbox wrapper to fix selection bug.
  - `checked` can be undefined

### Examples
- autoformat: `[]` will set a todo list item