### PR TITLE
feat: serialize option to override default render

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,6 +59,11 @@ export interface DeserializeHtml {
   leaf?: DeserializeNode[];
 }
 
+export interface SerializeHtml {
+  element?: RenderElement;
+  leaf?: RenderLeaf;
+}
+
 /**
  * Each plugin fields will be combined by role.
  *
@@ -71,10 +76,14 @@ export interface DeserializeHtml {
  *
  * To deserialize HTML:
  * - deserialize
+ *
+ * To serialize HTML (overriding renderElement / renderLeaf):
+ * - serialize
  */
 export interface SlatePlugin {
   decorate?: Decorate;
   deserialize?: DeserializeHtml;
+  serialize?: SerializeHtml;
   inlineTypes?: string[];
   renderElement?: RenderElement;
   renderLeaf?: RenderLeaf;

--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-serialize.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-serialize.spec.ts
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import {
+  BoldPlugin,
+  htmlStringToDOMNode,
+  ImagePlugin,
+  MARK_BOLD,
+} from '../../../index';
+import { serializeHTMLFromNodes } from '../index';
+
+it('custom serialize image to html', () => {
+  expect(
+    htmlStringToDOMNode(
+      serializeHTMLFromNodes({
+        plugins: [
+          {
+            ...ImagePlugin(),
+            serialize: {
+              element: ({ element }) =>
+                React.createElement('img', { src: element.url }),
+            },
+          },
+        ],
+        nodes: [
+          {
+            type: 'img',
+            url:
+              'https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg',
+            children: [],
+          },
+        ],
+      })
+    ).innerHTML
+  ).toEqual(
+    '<img src="https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg">'
+  );
+});
+
+it('custom serialize bold to html', () => {
+  expect(
+    serializeHTMLFromNodes({
+      plugins: [
+        {
+          ...BoldPlugin(),
+          serialize: {
+            leaf: ({ leaf, children }) =>
+              leaf[MARK_BOLD] && !!leaf.text
+                ? React.createElement('b', {}, children)
+                : children,
+          },
+        },
+      ],
+      nodes: [
+        { text: 'Some paragraph of text with ' },
+        { text: 'bold', bold: true },
+        { text: ' part.' },
+      ],
+    })
+  ).toEqual('Some paragraph of text with <b>bold</b> part.');
+});

--- a/packages/slate-plugins/src/serializers/serialize-html/serializeHTMLFromNodes.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/serializeHTMLFromNodes.ts
@@ -53,7 +53,7 @@ const getNode = ({
 
   // Search for matching plugin based on element type
   plugins.some((plugin) => {
-    if (!plugin.renderElement) return false;
+    if (!plugin.serialize?.element && !plugin.renderElement) return false;
     if (
       !plugin.deserialize?.element?.some(
         (item) => item.type === String(elementProps.element.type)
@@ -67,7 +67,9 @@ const getNode = ({
     html = renderToStaticMarkup(
       createElementWithSlate({
         ...slateProps,
-        children: plugin.renderElement(elementProps),
+        children:
+          plugin.serialize?.element?.(elementProps) ??
+          plugin.renderElement?.(elementProps),
       })
     );
 
@@ -91,8 +93,12 @@ const getLeaf = ({
   const { children } = leafProps;
 
   return plugins.reduce((result, plugin) => {
-    if (!plugin.renderLeaf) return result;
-    if (plugin.renderLeaf(leafProps) === children) return result;
+    if (!plugin.serialize?.leaf && !plugin.renderLeaf) return result;
+    if (
+      (plugin.serialize?.leaf?.(leafProps) ??
+        plugin.renderLeaf?.(leafProps)) === children
+    )
+      return result;
 
     const newLeafProps = {
       ...leafProps,
@@ -103,7 +109,9 @@ const getLeaf = ({
       renderToStaticMarkup(
         createElementWithSlate({
           ...slateProps,
-          children: plugin.renderLeaf(newLeafProps),
+          children:
+            plugin.serialize?.leaf?.(leafProps) ??
+            plugin.renderLeaf?.(newLeafProps),
         })
       )
     );


### PR DESCRIPTION
## Issue

 - #305 - serialize HTML with override of default editor render

## What I did

 - added `serialize` as a plugin option.  it accepts `element` and `leaf` properties.
 - `serializeHTMLFromNodes` will use `plugin.serialize.element` in place of `plugin.renderElement` and `plugin.serialize.leaf` in place of `plugin.renderLeaf`

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->