### PR TITLE
Set child type of a table cell to be `<p>`.

### DIFF
--- a/packages/slate-plugins/src/elements/table/utils/getEmptyCellNode.ts
+++ b/packages/slate-plugins/src/elements/table/utils/getEmptyCellNode.ts
@@ -1,4 +1,5 @@
 import { setDefaults } from '../../../common/utils/setDefaults';
+import { ELEMENT_PARAGRAPH } from '../../paragraph';
 import { DEFAULTS_TABLE } from '../defaults';
 import { TableOptions } from '../types';
 
@@ -9,6 +10,11 @@ export const getEmptyCellNode = (
 
   return {
     type: header ? th.type : td.type,
-    children: [{ text: '' }],
+    children: [
+      {
+        type: ELEMENT_PARAGRAPH,
+        children: [{ text: '' }],
+      },
+    ],
   };
 };


### PR DESCRIPTION

## Issue
#324 

Two reasons for this change:
1. This is to match the `createTable()` example in `initialValues.ts` in the storybook.
2. Currently a table cell's children is a `<span>` tag, which will give the
following warning when trying to visually style it with Align, List, etc.
```
Warning: validateDOMNesting(...): <td> cannot appear as a child of <div>.
```


## What I did
Set child type of a table cell to be `<p>` for the `TablePlugin`.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->