### PR TITLE
Continue using current marks on next list item

### DIFF
--- a/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
@@ -73,7 +73,7 @@ export const insertListItem = (editor: Editor, options?: ListOptions) => {
       /**
        * If end, insert a list item after and select it
        */
-      const marks = Editor.marks(editor) || {}
+      const marks = Editor.marks(editor) || {};
       Transforms.insertNodes(
         editor,
         {

--- a/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
@@ -73,11 +73,12 @@ export const insertListItem = (editor: Editor, options?: ListOptions) => {
       /**
        * If end, insert a list item after and select it
        */
+      const marks = Editor.marks(editor) || {}
       Transforms.insertNodes(
         editor,
         {
           type: li.type,
-          children: [{ type: p.type, children: [{ text: '' }] }],
+          children: [{ type: p.type, children: [{ text: '', ...marks }] }],
         },
         { at: nextListItemPath }
       );


### PR DESCRIPTION
## Issue
When creating a new list item, all of the current marks (bold, italic, etc..) are lost.


## What I did
Copy the marks from the current leaf node to the next


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->