### PR TITLE
feat: plugin deps

### DIFF
--- a/packages/core/src/__tests__/decoratePlugins/decorate-deps-without-plugin.spec.tsx
+++ b/packages/core/src/__tests__/decoratePlugins/decorate-deps-without-plugin.spec.tsx
@@ -1,0 +1,52 @@
+import React, { useMemo, useState } from 'react';
+import { render } from '@testing-library/react';
+import { createEditor, Node, Point } from 'slate';
+import { withHistory } from 'slate-history';
+import { Slate, withReact } from 'slate-react';
+import { Decorate } from '../..';
+import { pipe } from '../../../../slate-plugins/src/common/utils/pipe';
+import { EditablePlugins, EditablePluginsProps } from '../../components';
+
+const EditorWithDecorateDeps = ({
+  decorate,
+  decorateDeps,
+}: {
+  decorate: EditablePluginsProps['decorate'];
+  decorateDeps: EditablePluginsProps['decorateDeps'];
+}) => {
+  const [value, setValue] = useState<Node[]>([]);
+
+  const withPlugins = [withReact, withHistory] as const;
+
+  const editor = useMemo(() => pipe(createEditor(), ...withPlugins), [
+    withPlugins,
+  ]);
+
+  return (
+    <Slate
+      editor={editor}
+      value={value}
+      onChange={(newValue) => {
+        setValue(newValue);
+      }}
+    >
+      <EditablePlugins
+        data-testid="DecorateDepsWithoutPlugin"
+        decorate={decorate}
+        decorateDeps={decorateDeps}
+      />
+    </Slate>
+  );
+};
+
+it('should decorate with deps', () => {
+  const point: Point = { path: [0, 0], offset: 0 };
+  const range = { anchor: point, focus: point };
+  const decorate: Decorate = jest.fn(() => [range]);
+  const { getAllByTestId } = render(
+    <EditorWithDecorateDeps decorate={[decorate]} decorateDeps={[1]} />
+  );
+  // make sure everything rendered
+  expect(getAllByTestId('DecorateDepsWithoutPlugin').length).toBeGreaterThan(0);
+  expect(decorate).toHaveBeenCalledTimes(1);
+});

--- a/packages/core/src/__tests__/decoratePlugins/decorate-deps.spec.tsx
+++ b/packages/core/src/__tests__/decoratePlugins/decorate-deps.spec.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo, useState } from 'react';
+import { render } from '@testing-library/react';
+import { createEditor, Node, Point } from 'slate';
+import { withHistory } from 'slate-history';
+import { Slate, withReact } from 'slate-react';
+import { Decorate, SlatePlugin } from '../..';
+import { pipe } from '../../../../slate-plugins/src/common/utils/pipe';
+import { EditablePlugins, EditablePluginsProps } from '../../components';
+
+const EditorWithDecorateDeps = ({
+  decorate,
+  decorateDeps,
+  plugins,
+}: {
+  decorate: EditablePluginsProps['decorate'];
+  decorateDeps: EditablePluginsProps['decorateDeps'];
+  plugins: EditablePluginsProps['plugins'];
+}) => {
+  const [value, setValue] = useState<Node[]>([]);
+
+  const withPlugins = [withReact, withHistory] as const;
+
+  const editor = useMemo(() => pipe(createEditor(), ...withPlugins), [
+    withPlugins,
+  ]);
+
+  return (
+    <Slate
+      editor={editor}
+      value={value}
+      onChange={(newValue) => {
+        setValue(newValue);
+      }}
+    >
+      <EditablePlugins
+        data-testid="DecorateDeps"
+        decorate={decorate}
+        decorateDeps={decorateDeps}
+        plugins={plugins}
+      />
+    </Slate>
+  );
+};
+
+it('should decorate with deps', () => {
+  const point: Point = { path: [0, 0], offset: 0 };
+  const range = { anchor: point, focus: point };
+  const decorate: Decorate = jest.fn(() => [range]);
+
+  const plugins: SlatePlugin[] = [
+    {
+      decorateDeps: [1],
+    },
+  ];
+
+  const { getAllByTestId } = render(
+    <EditorWithDecorateDeps
+      decorate={[decorate]}
+      decorateDeps={[1]}
+      plugins={plugins}
+    />
+  );
+  // make sure everything rendered
+  expect(getAllByTestId('DecorateDeps').length).toBeGreaterThan(0);
+  expect(decorate).toHaveBeenCalledTimes(1);
+});

--- a/packages/core/src/components/EditablePlugins.tsx
+++ b/packages/core/src/components/EditablePlugins.tsx
@@ -103,23 +103,32 @@ export const EditablePlugins = ({
       }}
       decorate={useCallback(decoratePlugins(editor, plugins, decorateList), [
         editor,
-        ...decorateDeps,
+        ...[...plugins.flatMap((p) => p.decorateDeps ?? []), ...decorateDeps],
       ])}
       renderElement={useCallback(
         renderElementPlugins(plugins, renderElementList),
-        renderElementDeps
+        [
+          ...plugins.flatMap((p) => p.renderElementDeps ?? []),
+          ...renderElementDeps,
+        ]
       )}
-      renderLeaf={useCallback(
-        renderLeafPlugins(plugins, renderLeafList),
-        renderLeafDeps
-      )}
+      renderLeaf={useCallback(renderLeafPlugins(plugins, renderLeafList), [
+        ...plugins.flatMap((p) => p.renderLeafDeps ?? []),
+        ...renderLeafDeps,
+      ])}
       onDOMBeforeInput={useCallback(
         onDOMBeforeInputPlugins(editor, plugins, onDOMBeforeInputList),
-        [editor, ...onDOMBeforeInputDeps]
+        [
+          editor,
+          ...[
+            ...plugins.flatMap((p) => p.onDOMBeforeInputDeps ?? []),
+            ...onDOMBeforeInputDeps,
+          ],
+        ]
       )}
       onKeyDown={useCallback(onKeyDownPlugins(editor, plugins, onKeyDownList), [
         editor,
-        ...onKeyDownDeps,
+        ...[...plugins.flatMap((p) => p.onKeyDownDeps ?? []), ...onKeyDownDeps],
       ])}
       {...props}
     />

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -82,13 +82,23 @@ export interface SerializeHtml {
  */
 export interface SlatePlugin {
   decorate?: Decorate;
+  // Dependencies of `decorate`
+  decorateDeps?: any[];
   deserialize?: DeserializeHtml;
   serialize?: SerializeHtml;
   inlineTypes?: string[];
   renderElement?: RenderElement;
+  // Dependencies of `renderElement`
+  renderElementDeps?: any[];
   renderLeaf?: RenderLeaf;
+  // Dependencies of `renderLeaf`
+  renderLeafDeps?: any[];
   voidTypes?: string[];
   onDOMBeforeInput?: OnDOMBeforeInput;
+  // Dependencies of `onDOMBeforeInput`
+  onDOMBeforeInputDeps?: any[];
   onKeyDown?: OnKeyDown | null;
+  // Dependencies of `onKeyDown`
+  onKeyDownDeps?: any[];
   [key: string]: any;
 }


### PR DESCRIPTION
## Issue

Close #328

## What I did

Added deps props to the slate plugin definition to match the deps props on the SlateEditable component.

Specifically `SlatePlugin` gets the following properties.

```ts
  // Dependencies of `decorate`
  decorateDeps?: any[];
  // Dependencies of `renderElement`
  renderElementDeps?: any[];
  // Dependencies of `renderLeaf`
  renderLeafDeps?: any[];
  // Dependencies of `onDOMBeforeInput`
  onDOMBeforeInputDeps?: any[];
  // Dependencies of `onKeyDown`
  onKeyDownDeps?: any[];
```

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] Tests still work
- [ ] Unsure if stories need to be updated
- [ ] Unsure if my added test cases are useful

Regarding my test cases I was hoping to check somehow that memoization is working by checking `decorate.hasBeenCalledTimes(...)`. But decorate is called on every render so there isn't much to check. Now my test case basically checks that the component renders when decorate dependencies are passed. I can add similar test cases for the other dependencies I added but I wanted some feedback or ideas first.

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->