### PR TITLE
feat: deserialize plugin option to customize static deserialization

### DIFF
--- a/packages/slate-plugins/src/common/types/PluginOptions.types.ts
+++ b/packages/slate-plugins/src/common/types/PluginOptions.types.ts
@@ -1,3 +1,16 @@
+import { GetNodeDeserializerOptions, GetElementDeserializerOptions, GetLeafDeserializerOptions } from '../utils'
+
+export type DeserializerOptions =
+  | GetElementDeserializerOptions
+  | GetLeafDeserializerOptions;
+
+export interface Deserialize extends RenderNodeOptions {
+  /**
+   * `getElementDeserializer` and `getLeafDeserializer` options
+   */
+  deserialize?: Partial<DeserializerOptions>;
+}
+
 /**
  * Props of the root component of the component to render.
  */

--- a/packages/slate-plugins/src/common/types/PluginOptions.types.ts
+++ b/packages/slate-plugins/src/common/types/PluginOptions.types.ts
@@ -1,4 +1,7 @@
-import { GetNodeDeserializerOptions, GetElementDeserializerOptions, GetLeafDeserializerOptions } from '../utils'
+import {
+  GetElementDeserializerOptions,
+  GetLeafDeserializerOptions,
+} from '../utils';
 
 export type DeserializerOptions =
   | GetElementDeserializerOptions

--- a/packages/slate-plugins/src/common/utils/getElementDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getElementDeserializer.ts
@@ -1,7 +1,7 @@
 import {
   getNodeDeserializer,
   GetNodeDeserializerOptions,
-  WithOptional
+  WithOptional,
 } from './getNodeDeserializer';
 
 export interface GetElementDeserializerOptions

--- a/packages/slate-plugins/src/common/utils/getElementDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getElementDeserializer.ts
@@ -1,10 +1,11 @@
 import {
   getNodeDeserializer,
   GetNodeDeserializerOptions,
+  WithOptional
 } from './getNodeDeserializer';
 
 export interface GetElementDeserializerOptions
-  extends Omit<GetNodeDeserializerOptions, 'node'> {
+  extends WithOptional<GetNodeDeserializerOptions, 'node'> {
   type: string;
 }
 
@@ -15,6 +16,6 @@ export const getElementDeserializer = (
   options: GetElementDeserializerOptions
 ) =>
   getNodeDeserializer({
-    ...options,
     node: () => ({ type: options.type }),
+    ...options,
   });

--- a/packages/slate-plugins/src/common/utils/getLeafDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getLeafDeserializer.ts
@@ -1,10 +1,11 @@
 import {
   getNodeDeserializer,
   GetNodeDeserializerOptions,
+  WithOptional
 } from './getNodeDeserializer';
 
 export interface GetLeafDeserializerOptions
-  extends Omit<GetNodeDeserializerOptions, 'node'> {
+  extends WithOptional<GetNodeDeserializerOptions, 'node'> {
   type: string;
 }
 
@@ -13,6 +14,6 @@ export interface GetLeafDeserializerOptions
  */
 export const getLeafDeserializer = (options: GetLeafDeserializerOptions) =>
   getNodeDeserializer({
-    ...options,
     node: () => ({ [options.type]: true }),
+    ...options,
   });

--- a/packages/slate-plugins/src/common/utils/getLeafDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getLeafDeserializer.ts
@@ -1,7 +1,7 @@
 import {
   getNodeDeserializer,
   GetNodeDeserializerOptions,
-  WithOptional
+  WithOptional,
 } from './getNodeDeserializer';
 
 export interface GetLeafDeserializerOptions

--- a/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
@@ -1,6 +1,8 @@
 import { DeserializeNode } from '@udecode/slate-plugins-core';
 import castArray from 'lodash/castArray';
 
+export type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
 export interface GetNodeDeserializerRule {
   /**
    * Required node names to deserialize the element.

--- a/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
@@ -1,7 +1,8 @@
 import { DeserializeNode } from '@udecode/slate-plugins-core';
 import castArray from 'lodash/castArray';
 
-export type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+export type WithOptional<T, K extends keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>>;
 
 export interface GetNodeDeserializerRule {
   /**

--- a/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
+++ b/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
@@ -9,13 +9,9 @@ import { TablePlugin } from '../../../../elements/table/index';
 import { deserializeBold } from '../../../../marks/bold/deserializeBold';
 import { deserializeHTMLElement } from '../../../index';
 
-const textTags = [
-  '<b>strong</b>',
-];
+const textTags = ['<b>strong</b>'];
 
-const inlineTags = [
-  '<a href="http://google.com" target="_blank">a</a>',
-];
+const inlineTags = ['<a href="http://google.com" target="_blank">a</a>'];
 
 const elementTags = [
   '<img alt="removed" src="https://i.imgur.com/removed.png" />',
@@ -27,11 +23,41 @@ const html = `<html><body><p>${textTags.join('')}</p><p>${inlineTags.join(
 )}</p>${elementTags.join('')}</body></html>`;
 
 const input1 = [
-  ImagePlugin({ img: { deserialize: { node: (el) => ({ type: 'img', url: el.getAttribute('src'), alt: el.getAttribute('alt')}) } } }),
-  LinkPlugin({ link: { deserialize: { node: (el) => ({ type: 'a', url: el.getAttribute('href'), opener: el.getAttribute('target') === '_blank' }) } } }),
+  ImagePlugin({
+    img: {
+      deserialize: {
+        node: (el) => ({
+          type: 'img',
+          url: el.getAttribute('src'),
+          alt: el.getAttribute('alt'),
+        }),
+      },
+    },
+  }),
+  LinkPlugin({
+    link: {
+      deserialize: {
+        node: (el) => ({
+          type: 'a',
+          url: el.getAttribute('href'),
+          opener: el.getAttribute('target') === '_blank',
+        }),
+      },
+    },
+  }),
   ParagraphPlugin(),
-  TablePlugin({ td: { deserialize: { node: (el) => ({ type: 'td', colspan: el.getAttribute('colspan') }) } } }),
-  { deserialize: deserializeBold({ bold: { deserialize: { rules: [{ nodeNames: ['B'] }] } } }) },
+  TablePlugin({
+    td: {
+      deserialize: {
+        node: (el) => ({ type: 'td', colSpan: el.getAttribute('colspan') }),
+      },
+    },
+  }),
+  {
+    deserialize: deserializeBold({
+      bold: { deserialize: { rules: [{ nodeNames: ['B'] }] } },
+    }),
+  },
 ];
 const input2 = getHtmlDocument(html).body;
 
@@ -41,14 +67,16 @@ const output = (
       <htext bold>strong</htext>
     </hp>
     <hp>
-      <ha opener url="http://google.com">a</ha>
+      <ha opener url="http://google.com">
+        a
+      </ha>
     </hp>
     <himg alt="removed" url="https://i.imgur.com/removed.png">
       <htext />
     </himg>
     <htable>
       <htr>
-        <htd colspan="2">table</htd>
+        <htd colSpan="2">table</htd>
       </htr>
     </htable>
   </editor>

--- a/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
+++ b/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
@@ -1,0 +1,64 @@
+/** @jsx jsx */
+
+import { getHtmlDocument } from '../../../../__test-utils__/getHtmlDocument';
+import { jsx } from '../../../../__test-utils__/jsx';
+import { ImagePlugin } from '../../../../elements/image/index';
+import { LinkPlugin } from '../../../../elements/link/index';
+import { ParagraphPlugin } from '../../../../elements/paragraph/index';
+import { TablePlugin } from '../../../../elements/table/index';
+import { deserializeBold } from '../../../../marks/bold/deserializeBold';
+import { deserializeHTMLElement } from '../../../index';
+
+const textTags = [
+  '<b>strong</b>',
+];
+
+const inlineTags = [
+  '<a href="http://google.com" target="_blank">a</a>',
+];
+
+const elementTags = [
+  '<img alt="removed" src="https://i.imgur.com/removed.png" />',
+  '<table><tr><td colspan="2">table</td></tr></table>',
+];
+
+const html = `<html><body><p>${textTags.join('')}</p><p>${inlineTags.join(
+  ''
+)}</p>${elementTags.join('')}</body></html>`;
+
+const input1 = [
+  ImagePlugin({ img: { deserialize: { node: (el) => ({ type: 'img', url: el.getAttribute('src'), alt: el.getAttribute('alt')}) } } }),
+  LinkPlugin({ link: { deserialize: { node: (el) => ({ type: 'a', url: el.getAttribute('href'), opener: el.getAttribute('target') === '_blank' }) } } }),
+  ParagraphPlugin(),
+  TablePlugin({ td: { deserialize: { node: (el) => ({ type: 'td', colspan: el.getAttribute('colspan') }) } } }),
+  { deserialize: deserializeBold({ bold: { deserialize: { rules: [{ nodeNames: ['B'] }] } } }) },
+];
+const input2 = getHtmlDocument(html).body;
+
+const output = (
+  <editor>
+    <hp>
+      <htext bold>strong</htext>
+    </hp>
+    <hp>
+      <ha opener url="http://google.com">a</ha>
+    </hp>
+    <himg alt="removed" url="https://i.imgur.com/removed.png">
+      <htext />
+    </himg>
+    <htable>
+      <htr>
+        <htd colspan="2">table</htd>
+      </htr>
+    </htable>
+  </editor>
+) as any;
+
+it('should be', () => {
+  expect(
+    deserializeHTMLElement({
+      plugins: input1,
+      element: input2,
+    })
+  ).toEqual(output.children);
+});

--- a/packages/slate-plugins/src/elements/align/deserializeAlign.ts
+++ b/packages/slate-plugins/src/elements/align/deserializeAlign.ts
@@ -22,6 +22,7 @@ export const deserializeAlign = (
             },
           },
         ],
+        ...options?.align_center?.deserialize,
       }),
       ...getElementDeserializer({
         type: align_right.type,
@@ -34,6 +35,7 @@ export const deserializeAlign = (
             },
           },
         ],
+        ...options?.align_right?.deserialize,
       }),
     ],
   };

--- a/packages/slate-plugins/src/elements/align/types.ts
+++ b/packages/slate-plugins/src/elements/align/types.ts
@@ -1,6 +1,7 @@
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -28,7 +29,8 @@ export type AlignKeyOption = 'align_left' | 'align_center' | 'align_right';
 
 // Plugin options
 export type AlignPluginOptionsValues = RenderNodeOptions &
-  RootProps<AlignRenderElementPropsOptions>;
+  RootProps<AlignRenderElementPropsOptions> &
+  Deserialize;
 export type AlignPluginOptionsKeys = keyof AlignPluginOptionsValues;
 export type AlignPluginOptions<
   Value extends AlignPluginOptionsKeys = AlignPluginOptionsKeys
@@ -41,4 +43,4 @@ export interface AlignRenderElementOptions
 
 // deserialize options
 export interface AlignDeserializeOptions
-  extends AlignPluginOptions<'type' | 'rootProps'> {}
+  extends AlignPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/elements/blockquote/deserializeBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/deserializeBlockquote.ts
@@ -13,6 +13,7 @@ export const deserializeBlockquote = (
     element: getElementDeserializer({
       type: blockquote.type,
       rules: [{ nodeNames: 'BLOCKQUOTE' }],
+      ...options?.blockquote?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -3,6 +3,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -37,7 +38,8 @@ export type BlockquoteKeyOption = 'blockquote';
 
 // Plugin options
 export type BlockquotePluginOptionsValues = RenderNodeOptions &
-  RootProps<BlockquoteRenderElementPropsOptions>;
+  RootProps<BlockquoteRenderElementPropsOptions> &
+  Deserialize;
 export type BlockquotePluginOptionsKeys = keyof BlockquotePluginOptionsValues;
 export type BlockquotePluginOptions<
   Value extends BlockquotePluginOptionsKeys = BlockquotePluginOptionsKeys
@@ -52,7 +54,7 @@ export interface BlockquoteRenderElementOptions
 
 // deserialize options
 export interface BlockquoteDeserializeOptions
-  extends BlockquotePluginOptions<'type' | 'rootProps'> {}
+  extends BlockquotePluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface BlockquoteElementStyles {
   /**

--- a/packages/slate-plugins/src/elements/code-block/deserializeCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/deserializeCodeBlock.ts
@@ -13,6 +13,7 @@ export const deserializeCodeBlock = (
     element: getElementDeserializer({
       type: code_block.type,
       rules: [{ nodeNames: 'PRE' }],
+      ...options?.code_block?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/elements/code-block/types.ts
+++ b/packages/slate-plugins/src/elements/code-block/types.ts
@@ -3,6 +3,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -36,7 +37,8 @@ export type CodeBlockKeyOption = 'code_block';
 
 // Plugin options
 export type CodeBlockPluginOptionsValues = RenderNodeOptions &
-  RootProps<CodeBlockRenderElementPropsOptions>;
+  RootProps<CodeBlockRenderElementPropsOptions> &
+  Deserialize;
 export type CodeBlockPluginOptionsKeys = keyof CodeBlockPluginOptionsValues;
 export type CodeBlockPluginOptions<
   Value extends CodeBlockPluginOptionsKeys = CodeBlockPluginOptionsKeys
@@ -51,7 +53,7 @@ export interface CodeBlockRenderElementOptions
 
 // deserialize options
 export interface CodeBlockDeserializeOptions
-  extends CodeBlockPluginOptions<'type' | 'rootProps'> {}
+  extends CodeBlockPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface CodeBlockElementStyles {
   /**

--- a/packages/slate-plugins/src/elements/heading/deserializeHeading.ts
+++ b/packages/slate-plugins/src/elements/heading/deserializeHeading.ts
@@ -15,6 +15,7 @@ export const deserializeHeading = (
   let deserializers = getElementDeserializer({
     type: h1.type,
     rules: [{ nodeNames: 'H1' }],
+    ...options?.h1?.deserialize,
   });
 
   if (levels >= 2)
@@ -23,6 +24,7 @@ export const deserializeHeading = (
       ...getElementDeserializer({
         type: h2.type,
         rules: [{ nodeNames: 'H2' }],
+        ...options?.h2?.deserialize,
       }),
     ];
   if (levels >= 3)
@@ -31,6 +33,7 @@ export const deserializeHeading = (
       ...getElementDeserializer({
         type: h3.type,
         rules: [{ nodeNames: 'H3' }],
+        ...options?.h3?.deserialize,
       }),
     ];
   if (levels >= 4)
@@ -39,6 +42,7 @@ export const deserializeHeading = (
       ...getElementDeserializer({
         type: h4.type,
         rules: [{ nodeNames: 'H4' }],
+        ...options?.h4?.deserialize,
       }),
     ];
   if (levels >= 5)
@@ -47,6 +51,7 @@ export const deserializeHeading = (
       ...getElementDeserializer({
         type: h5.type,
         rules: [{ nodeNames: 'H5' }],
+        ...options?.h5?.deserialize,
       }),
     ];
   if (levels >= 6)
@@ -55,6 +60,7 @@ export const deserializeHeading = (
       ...getElementDeserializer({
         type: h6.type,
         rules: [{ nodeNames: 'H6' }],
+        ...options?.h6?.deserialize,
       }),
     ];
 

--- a/packages/slate-plugins/src/elements/heading/types.ts
+++ b/packages/slate-plugins/src/elements/heading/types.ts
@@ -2,6 +2,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -48,7 +49,8 @@ export type HeadingKeyOption = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 // Plugin options
 export type HeadingPluginOptionsValues = RenderNodeOptions &
-  RootProps<HeadingRenderElementPropsOptions>;
+  RootProps<HeadingRenderElementPropsOptions> &
+  Deserialize;
 export type HeadingPluginOptionsKeys = keyof HeadingPluginOptionsValues;
 export type HeadingPluginOptions<
   Value extends HeadingPluginOptionsKeys = HeadingPluginOptionsKeys
@@ -63,5 +65,5 @@ export interface HeadingRenderElementOptions
 
 // deserialize options
 export interface HeadingDeserializeOptions
-  extends HeadingPluginOptions<'type' | 'rootProps'>,
+  extends HeadingPluginOptions<'type' | 'rootProps' | 'deserialize'>,
     HeadingLevelsOption {}

--- a/packages/slate-plugins/src/elements/image/deserializeImage.ts
+++ b/packages/slate-plugins/src/elements/image/deserializeImage.ts
@@ -17,6 +17,7 @@ export const deserializeImage = (
         url: el.getAttribute('src'),
       }),
       rules: [{ nodeNames: 'IMG' }],
+      ...options?.img?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -3,6 +3,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -35,7 +36,8 @@ export type ImageKeyOption = 'img';
 
 // Plugin options
 export type ImagePluginOptionsValues = RenderNodeOptions &
-  RootProps<ImageRenderElementPropsOptions>;
+  RootProps<ImageRenderElementPropsOptions> &
+  Deserialize;
 export type ImagePluginOptionsKeys = keyof ImagePluginOptionsValues;
 export type ImagePluginOptions<
   Value extends ImagePluginOptionsKeys = ImagePluginOptionsKeys
@@ -48,7 +50,7 @@ export interface ImageRenderElementOptions
 
 // deserialize options
 export interface ImageDeserializeOptions
-  extends ImagePluginOptions<'type' | 'rootProps'> {}
+  extends ImagePluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface ImageElementStyles {
   /**

--- a/packages/slate-plugins/src/elements/link/deserializeLink.ts
+++ b/packages/slate-plugins/src/elements/link/deserializeLink.ts
@@ -17,6 +17,7 @@ export const deserializeLink = (
         url: el.getAttribute('href'),
       }),
       rules: [{ nodeNames: 'A' }],
+      ...options?.link?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -4,6 +4,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import { RangeBeforeOptions } from '../../common/queries/getRangeBefore';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -43,7 +44,8 @@ export type LinkKeyOption = 'link';
 
 // Plugin options
 export type LinkPluginOptionsValues = RenderNodeOptions &
-  RootProps<LinkRenderElementPropsOptions> & {
+  RootProps<LinkRenderElementPropsOptions> &
+  Deserialize & {
     /**
      * Callback to validate an url.
      */
@@ -61,7 +63,7 @@ export interface LinkRenderElementOptions
 
 // deserialize options
 export interface LinkDeserializeOptions
-  extends LinkPluginOptions<'type' | 'rootProps'> {}
+  extends LinkPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface WithLinkOptions extends LinkPluginOptions<'type' | 'isUrl'> {
   /**

--- a/packages/slate-plugins/src/elements/list/deserializeList.ts
+++ b/packages/slate-plugins/src/elements/list/deserializeList.ts
@@ -14,14 +14,17 @@ export const deserializeList = (
       ...getElementDeserializer({
         type: ul.type,
         rules: [{ nodeNames: 'UL' }],
+        ...options?.ul?.deserialize,
       }),
       ...getElementDeserializer({
         type: ol.type,
         rules: [{ nodeNames: 'OL' }],
+        ...options?.ol?.deserialize,
       }),
       ...getElementDeserializer({
         type: li.type,
         rules: [{ nodeNames: 'LI' }],
+        ...options?.li?.deserialize,
       }),
     ],
   };

--- a/packages/slate-plugins/src/elements/list/types.ts
+++ b/packages/slate-plugins/src/elements/list/types.ts
@@ -2,6 +2,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -45,7 +46,8 @@ export type ListKeyOption = 'ul' | 'ol' | 'li' | 'p';
 
 // Plugin options
 export type ListPluginOptionsValues = RenderNodeOptions &
-  RootProps<ListRenderElementPropsOptions>;
+  RootProps<ListRenderElementPropsOptions> &
+  Deserialize;
 export type ListPluginOptionsKeys = keyof ListPluginOptionsValues;
 export type ListPluginOptions<
   Value extends ListPluginOptionsKeys = ListPluginOptionsKeys
@@ -58,7 +60,7 @@ export interface ListRenderElementOptions
 
 // deserialize options
 export interface ListDeserializeOptions
-  extends ListPluginOptions<'type' | 'rootProps'> {}
+  extends ListPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface ListOnKeyDownOptions extends ListPluginOptions<'type'> {}
 export interface ListOptions extends ListPluginOptions<'type'> {}

--- a/packages/slate-plugins/src/elements/media-embed/deserializeIframe.ts
+++ b/packages/slate-plugins/src/elements/media-embed/deserializeIframe.ts
@@ -27,6 +27,7 @@ export const deserializeIframe = (
         { nodeNames: 'IFRAME' },
         { className: media_embed.rootProps.className },
       ],
+      ...options?.media_embed?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/elements/media-embed/types.ts
+++ b/packages/slate-plugins/src/elements/media-embed/types.ts
@@ -3,6 +3,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -42,7 +43,8 @@ export type MediaEmbedKeyOption = 'media_embed';
 
 // Plugin options
 export type MediaEmbedPluginOptionsValues = RenderNodeOptions &
-  RootProps<MediaEmbedRenderElementPropsOptions>;
+  RootProps<MediaEmbedRenderElementPropsOptions> &
+  Deserialize;
 export type MediaEmbedPluginOptionsKeys = keyof MediaEmbedPluginOptionsValues;
 export type MediaEmbedPluginOptions<
   Value extends MediaEmbedPluginOptionsKeys = MediaEmbedPluginOptionsKeys
@@ -57,7 +59,7 @@ export interface MediaEmbedRenderElementOptions
 
 // deserialize options
 export interface MediaEmbedDeserializeOptions
-  extends MediaEmbedPluginOptions<'type' | 'rootProps'> {}
+  extends MediaEmbedPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface MediaEmbedElementStyles {
   /**

--- a/packages/slate-plugins/src/elements/mention/deserializeMention.ts
+++ b/packages/slate-plugins/src/elements/mention/deserializeMention.ts
@@ -17,6 +17,7 @@ export const deserializeMention = (
         value: el.getAttribute('data-slate-value'),
       }),
       rules: [{ className: mention.rootProps.className }],
+      ...options?.mention?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -3,6 +3,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -53,7 +54,8 @@ export type MentionKeyOption = 'mention';
 
 // Plugin options
 export type MentionPluginOptionsValues = RenderNodeOptions &
-  RootProps<MentionRenderElementPropsOptions>;
+  RootProps<MentionRenderElementPropsOptions> &
+  Deserialize;
 export type MentionPluginOptionsKeys = keyof MentionPluginOptionsValues;
 export type MentionPluginOptions<
   Value extends MentionPluginOptionsKeys = MentionPluginOptionsKeys
@@ -66,7 +68,7 @@ export interface MentionRenderElementOptions
 
 // deserialize options
 export interface MentionDeserializeOptions
-  extends MentionPluginOptions<'type' | 'rootProps'> {}
+  extends MentionPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface WithMentionOptions extends MentionPluginOptions<'type'> {}
 

--- a/packages/slate-plugins/src/elements/paragraph/deserializeParagraph.ts
+++ b/packages/slate-plugins/src/elements/paragraph/deserializeParagraph.ts
@@ -13,6 +13,7 @@ export const deserializeParagraph = (
     element: getElementDeserializer({
       type: p.type,
       rules: [{ nodeNames: 'P' }],
+      ...options?.p?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/elements/paragraph/types.ts
+++ b/packages/slate-plugins/src/elements/paragraph/types.ts
@@ -1,6 +1,7 @@
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -28,7 +29,8 @@ export type ParagraphKeyOption = 'p';
 
 // Plugin options
 export type ParagraphPluginOptionsValues = RenderNodeOptions &
-  RootProps<ParagraphRenderElementPropsOptions>;
+  RootProps<ParagraphRenderElementPropsOptions> &
+  Deserialize;
 export type ParagraphPluginOptionsKeys = keyof ParagraphPluginOptionsValues;
 export type ParagraphPluginOptions<
   Value extends ParagraphPluginOptionsKeys = ParagraphPluginOptionsKeys
@@ -43,4 +45,4 @@ export interface ParagraphRenderElementOptions
 
 // deserialize options
 export interface ParagraphDeserializeOptions
-  extends ParagraphPluginOptions<'type' | 'rootProps'> {}
+  extends ParagraphPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/elements/table/deserializeTable.ts
+++ b/packages/slate-plugins/src/elements/table/deserializeTable.ts
@@ -14,18 +14,22 @@ export const deserializeTable = (
       ...getElementDeserializer({
         type: table.type,
         rules: [{ nodeNames: 'TABLE' }],
+        ...options?.table?.deserialize,
       }),
       ...getElementDeserializer({
         type: tr.type,
         rules: [{ nodeNames: 'TR' }],
+        ...options?.tr?.deserialize,
       }),
       ...getElementDeserializer({
         type: td.type,
         rules: [{ nodeNames: 'TD' }],
+        ...options?.td?.deserialize,
       }),
       ...getElementDeserializer({
         type: th.type,
         rules: [{ nodeNames: 'TH' }],
+        ...options?.th?.deserialize,
       }),
     ],
   };

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -3,6 +3,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -33,7 +34,8 @@ export type TableKeyOption = 'table' | 'th' | 'tr' | 'td';
 
 // Plugin options
 export type TablePluginOptionsValues = RenderNodeOptions &
-  RootProps<TableRenderElementPropsOptions>;
+  RootProps<TableRenderElementPropsOptions> &
+  Deserialize;
 export type TablePluginOptionsKeys = keyof TablePluginOptionsValues;
 export type TablePluginOptions<
   Value extends TablePluginOptionsKeys = TablePluginOptionsKeys
@@ -46,7 +48,7 @@ export interface TableRenderElementOptions
 
 // deserialize options
 export interface TableDeserializeOptions
-  extends TablePluginOptions<'type' | 'rootProps'> {}
+  extends TablePluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
 export interface WithTableOptions extends TablePluginOptions<'type'> {}
 export interface TableOptions extends TablePluginOptions<'type'> {}

--- a/packages/slate-plugins/src/marks/bold/deserializeBold.ts
+++ b/packages/slate-plugins/src/marks/bold/deserializeBold.ts
@@ -20,6 +20,7 @@ export const deserializeBold = (
           },
         },
       ],
+      ...options?.bold?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/bold/types.ts
+++ b/packages/slate-plugins/src/marks/bold/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type BoldKeyOption = 'bold';
 // Plugin options
 export type BoldPluginOptionsValues = RenderNodeOptions &
   RootProps<BoldRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type BoldPluginOptionsKeys = keyof BoldPluginOptionsValues;
 export type BoldPluginOptions<
   Value extends BoldPluginOptionsKeys = BoldPluginOptionsKeys
@@ -43,4 +45,4 @@ export interface BoldRenderLeafOptions
 
 // deserialize options
 export interface BoldDeserializeOptions
-  extends BoldPluginOptions<'type' | 'rootProps'> {}
+  extends BoldPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/code/deserializeCode.ts
+++ b/packages/slate-plugins/src/marks/code/deserializeCode.ts
@@ -20,6 +20,7 @@ export const deserializeCode = (
           },
         },
       ],
+      ...options?.code?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/code/types.ts
+++ b/packages/slate-plugins/src/marks/code/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type CodeKeyOption = 'code';
 // Plugin options
 export type CodePluginOptionsValues = RenderNodeOptions &
   RootProps<CodeRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type CodePluginOptionsKeys = keyof CodePluginOptionsValues;
 export type CodePluginOptions<
   Value extends CodePluginOptionsKeys = CodePluginOptionsKeys
@@ -43,4 +45,4 @@ export interface CodeRenderLeafOptions
 
 // deserialize options
 export interface CodeDeserializeOptions
-  extends CodePluginOptions<'type' | 'rootProps'> {}
+  extends CodePluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/highlight/deserializeHighlight.ts
+++ b/packages/slate-plugins/src/marks/highlight/deserializeHighlight.ts
@@ -13,6 +13,7 @@ export const deserializeHighlight = (
     leaf: getLeafDeserializer({
       type: highlight.type,
       rules: [{ nodeNames: ['MARK'] }],
+      ...options?.highlight?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/highlight/types.ts
+++ b/packages/slate-plugins/src/marks/highlight/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type HighlightKeyOption = 'highlight';
 // Plugin options
 export type HighlightPluginOptionsValues = RenderNodeOptions &
   RootProps<HighlightRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type HighlightPluginOptionsKeys = keyof HighlightPluginOptionsValues;
 export type HighlightPluginOptions<
   Value extends HighlightPluginOptionsKeys = HighlightPluginOptionsKeys
@@ -45,4 +47,4 @@ export interface HighlightRenderLeafOptions
 
 // deserialize options
 export interface HighlightDeserializeOptions
-  extends HighlightPluginOptions<'type' | 'rootProps'> {}
+  extends HighlightPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/italic/deserializeItalic.ts
+++ b/packages/slate-plugins/src/marks/italic/deserializeItalic.ts
@@ -20,6 +20,7 @@ export const deserializeItalic = (
           },
         },
       ],
+      ...options?.italic?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/italic/types.ts
+++ b/packages/slate-plugins/src/marks/italic/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type ItalicKeyOption = 'italic';
 // Plugin options
 export type ItalicPluginOptionsValues = RenderNodeOptions &
   RootProps<ItalicRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type ItalicPluginOptionsKeys = keyof ItalicPluginOptionsValues;
 export type ItalicPluginOptions<
   Value extends ItalicPluginOptionsKeys = ItalicPluginOptionsKeys
@@ -43,4 +45,4 @@ export interface ItalicRenderLeafOptions
 
 // deserialize options
 export interface ItalicDeserializeOptions
-  extends ItalicPluginOptions<'type' | 'rootProps'> {}
+  extends ItalicPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/kbd/deserializeKbd.ts
+++ b/packages/slate-plugins/src/marks/kbd/deserializeKbd.ts
@@ -20,6 +20,7 @@ export const deserializeKbd = (
           },
         },
       ],
+      ...options?.kbd?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/kbd/types.ts
+++ b/packages/slate-plugins/src/marks/kbd/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type KbdKeyOption = 'kbd';
 // Plugin options
 export type KbdPluginOptionsValues = RenderNodeOptions &
   RootProps<KbdRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type KbdPluginOptionsKeys = keyof KbdPluginOptionsValues;
 export type KbdPluginOptions<
   Value extends KbdPluginOptionsKeys = KbdPluginOptionsKeys
@@ -43,4 +45,4 @@ export interface KbdRenderLeafOptions
 
 // deserialize options
 export interface KbdDeserializeOptions
-  extends KbdPluginOptions<'type' | 'rootProps'> {}
+  extends KbdPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/strikethrough/deserializeStrikethrough.ts
+++ b/packages/slate-plugins/src/marks/strikethrough/deserializeStrikethrough.ts
@@ -20,6 +20,7 @@ export const deserializeStrikethrough = (
           },
         },
       ],
+      ...options?.strikethrough?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/strikethrough/types.ts
+++ b/packages/slate-plugins/src/marks/strikethrough/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type StrikethroughKeyOption = 'strikethrough';
 // Plugin options
 export type StrikethroughPluginOptionsValues = RenderNodeOptions &
   RootProps<StrikethroughRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type StrikethroughPluginOptionsKeys = keyof StrikethroughPluginOptionsValues;
 export type StrikethroughPluginOptions<
   Value extends StrikethroughPluginOptionsKeys = StrikethroughPluginOptionsKeys
@@ -45,4 +47,4 @@ export interface StrikethroughRenderLeafOptions
 
 // deserialize options
 export interface StrikethroughDeserializeOptions
-  extends StrikethroughPluginOptions<'type' | 'rootProps'> {}
+  extends StrikethroughPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/subsupscript/subscript/deserializeSubscript.ts
+++ b/packages/slate-plugins/src/marks/subsupscript/subscript/deserializeSubscript.ts
@@ -20,6 +20,7 @@ export const deserializeSubscript = (
           },
         },
       ],
+      ...options?.subscript?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/subsupscript/subscript/types.ts
+++ b/packages/slate-plugins/src/marks/subsupscript/subscript/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type SubscriptKeyOption = 'subscript';
 // Plugin options
 export type SubscriptPluginOptionsValues = RenderNodeOptions &
   RootProps<SubscriptRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type SubscriptPluginOptionsKeys = keyof SubscriptPluginOptionsValues;
 export type SubscriptPluginOptions<
   Value extends SubscriptPluginOptionsKeys = SubscriptPluginOptionsKeys
@@ -45,4 +47,4 @@ export interface SubscriptRenderLeafOptions
 
 // deserialize options
 export interface SubscriptDeserializeOptions
-  extends SubscriptPluginOptions<'type' | 'rootProps'> {}
+  extends SubscriptPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/subsupscript/superscript/deserializeSuperscript.ts
+++ b/packages/slate-plugins/src/marks/subsupscript/superscript/deserializeSuperscript.ts
@@ -20,6 +20,7 @@ export const deserializeSuperscript = (
           },
         },
       ],
+      ...options?.superscript?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/subsupscript/superscript/types.ts
+++ b/packages/slate-plugins/src/marks/subsupscript/superscript/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type SuperscriptKeyOption = 'superscript';
 // Plugin options
 export type SuperscriptPluginOptionsValues = RenderNodeOptions &
   RootProps<SuperscriptRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type SuperscriptPluginOptionsKeys = keyof SuperscriptPluginOptionsValues;
 export type SuperscriptPluginOptions<
   Value extends SuperscriptPluginOptionsKeys = SuperscriptPluginOptionsKeys
@@ -45,4 +47,4 @@ export interface SuperscriptRenderLeafOptions
 
 // deserialize options
 export interface SuperscriptDeserializeOptions
-  extends SuperscriptPluginOptions<'type' | 'rootProps'> {}
+  extends SuperscriptPluginOptions<'type' | 'rootProps' | 'deserialize'> {}

--- a/packages/slate-plugins/src/marks/underline/deserializeUnderline.ts
+++ b/packages/slate-plugins/src/marks/underline/deserializeUnderline.ts
@@ -20,6 +20,7 @@ export const deserializeUnderline = (
           },
         },
       ],
+      ...options?.underline?.deserialize,
     }),
   };
 };

--- a/packages/slate-plugins/src/marks/underline/types.ts
+++ b/packages/slate-plugins/src/marks/underline/types.ts
@@ -1,6 +1,7 @@
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 import {
+  Deserialize,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,7 +31,8 @@ export type UnderlineKeyOption = 'underline';
 // Plugin options
 export type UnderlinePluginOptionsValues = RenderNodeOptions &
   RootProps<UnderlineRenderLeafPropsOptions> &
-  Partial<GetOnHotkeyToggleMarkOptions>;
+  Partial<GetOnHotkeyToggleMarkOptions> &
+  Deserialize;
 export type UnderlinePluginOptionsKeys = keyof UnderlinePluginOptionsValues;
 export type UnderlinePluginOptions<
   Value extends UnderlinePluginOptionsKeys = UnderlinePluginOptionsKeys
@@ -45,4 +47,4 @@ export interface UnderlineRenderLeafOptions
 
 // deserialize options
 export interface UnderlineDeserializeOptions
-  extends UnderlinePluginOptions<'type' | 'rootProps'> {}
+  extends UnderlinePluginOptions<'type' | 'rootProps' | 'deserialize'> {}


### PR DESCRIPTION
## Issue

When deserializing, sometimes I am unable to utilize the default deserializer...
- when I need an alternative rule to match (eg. `nodeNames: ['B']` vs. `nodeNames: ['STRONG']`)
- when I need to get an attribute via the node (eg. `(el) => ({ alt: el.getAttribute('alt') })` )
- when I want to override `attributes` (with PR #323)
but otherwise want to use Plugin features

Rather than having to write a custom plugin (even one stripped down to only `deserialize`), it would be nicer to be able to override `rules`, `node`, and `attributes` via the plugin options

## What I did

Added a `deserialize` option to plugin options that will spread over any existing `rules`, `node`, and `attributes`.  In order to accommodate adding a `node` option even when `getElementDeserializer` is called, I tweaked `GetElementDeserializer` and `GetLeafDeserializer` to optionally take a node property (and not omit it).

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->