### PR TITLE
Fix deleting from start of list and deleting a fragment

### DIFF
--- a/packages/slate-plugins/src/common/transforms/moveChildren.ts
+++ b/packages/slate-plugins/src/common/transforms/moveChildren.ts
@@ -1,0 +1,33 @@
+import { Editor, Node, NodeEntry, Path, Transforms } from 'slate';
+
+export interface Options {
+  start?: number;
+  pass?(entry: NodeEntry): boolean;
+}
+
+/**
+ * Extracts the children from a list item moving them outside the list
+ */
+export function moveChildren(
+  editor: Editor,
+  parent: NodeEntry | Path,
+  to: Path,
+  options: Options = {}
+) {
+  let moved = 0;
+  const { pass, start = 0 } = options;
+  const parentPath = Path.isPath(parent) ? parent : parent[1];
+  const parentNode = Path.isPath(parent)
+    ? Node.get(editor, parentPath)
+    : parent[0];
+  if (!Editor.isBlock(editor, parentNode)) return;
+
+  for (let i = parentNode.children.length - 1; i >= start; i--) {
+    const childPath = [...parentPath, i];
+    if (!pass || pass([Node.get(editor, childPath), childPath])) {
+      Transforms.moveNodes(editor, { at: childPath, to });
+      moved++;
+    }
+  }
+  return moved;
+}

--- a/packages/slate-plugins/src/elements/list/__tests__/transforms/deleteListFragment.test.ts
+++ b/packages/slate-plugins/src/elements/list/__tests__/transforms/deleteListFragment.test.ts
@@ -1,0 +1,487 @@
+import { createEditor, Editor, Range, Transforms } from 'slate';
+import { withHistory } from 'slate-history';
+import { deleteListFragment } from '../../transforms/deleteListFragment';
+
+const ONEPATH = [0, 1, 0, 0, 0];
+const TWOPATH = [0, 1, 0, 1, 0, 0, 0];
+const THREEPATH = [0, 1, 0, 1, 0, 1, 0, 0, 0];
+
+function createExampleNodes() {
+  return {
+    // [0]
+    children: [
+      {
+        type: 'p',
+        children: [{ text: 'before' }],
+      },
+      {
+        // [0, 1]
+        type: 'ul',
+        children: [
+          {
+            // [0, 1, 0]
+            type: 'li',
+            children: [
+              {
+                type: 'p',
+                children: [{ text: 'one' }],
+              },
+              {
+                // [0, 1, 0, 1]
+                type: 'ul',
+                children: [
+                  {
+                    // [0, 1, 0, 1, 0]
+                    type: 'li',
+                    children: [
+                      {
+                        type: 'p',
+                        children: [{ text: 'two' }],
+                      },
+                      {
+                        // [0, 1, 0, 1, 0, 1]
+                        type: 'ul',
+                        children: [
+                          {
+                            // [0, 1, 0, 1, 0, 1, 0]
+                            type: 'li',
+                            children: [
+                              {
+                                // [0, 1, 0, 1, 0, 1, 0, 1]
+                                type: 'p',
+                                children: [{ text: 'three' }],
+                              },
+                            ],
+                          },
+                          {
+                            // [0, 1, 0, 1, 0, 1, 1]
+                            type: 'li',
+                            children: [
+                              {
+                                // [0, 1, 0, 1, 0, 1, 1, 1]
+                                type: 'p',
+                                children: [{ text: 'four' }],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    // [0, 1, 0, 1, 1]
+                    type: 'li',
+                    children: [{ type: 'p', children: [{ text: 'five' }] }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            // [0, 1, 1]
+            type: 'li',
+            children: [{ type: 'p', children: [{ text: 'six' }] }],
+          },
+        ],
+      },
+      {
+        type: 'p',
+        children: [{ text: 'after' }],
+      },
+    ],
+  };
+}
+
+function createExample(editor: Editor = createEditor()) {
+  Transforms.insertNodes(editor, createExampleNodes());
+  return editor;
+}
+
+describe('deleteListFragment', () => {
+  describe('unhandled', () => {
+    it(`doesn't handle deletes that are within a single list item`, () => {
+      const editor = createExample();
+      const selection: Range = {
+        anchor: { path: [0], offset: 0 },
+        focus: { path: [0], offset: 0 },
+      };
+      const actual = deleteListFragment(editor, selection);
+
+      expect(actual).toBeUndefined();
+    });
+
+    it(`doesn't handle deletes when the end is outside of the list`, () => {
+      const editor = createExample();
+      const selection: Range = {
+        anchor: { path: [0, 0], offset: 0 },
+        focus: { path: [0, 2], offset: 4 },
+      };
+      const actual = deleteListFragment(editor, selection);
+
+      expect(actual).toBeUndefined();
+    });
+  });
+
+  describe('deletes top of list', () => {
+    it('deletes the entire first list item from the top of the list', () => {
+      const editor = withHistory(createExample());
+      // select from 'above' to 'one'
+      const selection: Range = {
+        anchor: { path: [0, 0, 0], offset: 0 },
+        focus: { path: ONEPATH, offset: 3 },
+      };
+
+      const actual = deleteListFragment(editor, selection);
+
+      expect(actual).toEqual(3);
+      const expected = [
+        {
+          children: [
+            {
+              type: 'p',
+              children: [{ text: '' }],
+            },
+            {
+              type: 'ul',
+              children: [
+                {
+                  type: 'li',
+                  children: [
+                    {
+                      type: 'p',
+                      children: [{ text: 'two' }],
+                    },
+                    {
+                      type: 'ul',
+                      children: [
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [{ text: 'three' }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [{ text: 'four' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'li',
+                  children: [{ type: 'p', children: [{ text: 'five' }] }],
+                },
+                {
+                  type: 'li',
+                  children: [{ type: 'p', children: [{ text: 'six' }] }],
+                },
+              ],
+            },
+            {
+              type: 'p',
+              children: [{ text: 'after' }],
+            },
+          ],
+        },
+      ];
+      expect(editor.children).toEqual(expected);
+
+      // test undo
+      editor.undo();
+
+      const expectedUndo = [createExampleNodes()];
+      expect(editor.children).toEqual(expectedUndo);
+    });
+
+    it('partially deletes the first list item', () => {
+      const editor = withHistory(createExample());
+      // select from 'above' to 'one'
+      const selection: Range = {
+        anchor: { path: [0, 0, 0], offset: 0 },
+        focus: { path: ONEPATH, offset: 2 },
+      };
+
+      const actual = deleteListFragment(editor, selection);
+
+      expect(actual).toEqual(3);
+      const expected = [
+        {
+          children: [
+            {
+              type: 'p',
+              children: [{ text: 'e' }],
+            },
+            {
+              type: 'ul',
+              children: [
+                {
+                  type: 'li',
+                  children: [
+                    {
+                      type: 'p',
+                      children: [{ text: 'two' }],
+                    },
+                    {
+                      type: 'ul',
+                      children: [
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [{ text: 'three' }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [{ text: 'four' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'li',
+                  children: [{ type: 'p', children: [{ text: 'five' }] }],
+                },
+                {
+                  type: 'li',
+                  children: [{ type: 'p', children: [{ text: 'six' }] }],
+                },
+              ],
+            },
+            {
+              type: 'p',
+              children: [{ text: 'after' }],
+            },
+          ],
+        },
+      ];
+      expect(editor.children).toEqual(expected);
+
+      // test undo
+      editor.undo();
+
+      const expectedUndo = [createExampleNodes()];
+      expect(editor.children).toEqual(expectedUndo);
+    });
+  });
+
+  describe('deletes inside the list', () => {
+    it("deep delete doesn't require moving siblings", () => {
+      const editor = withHistory(createExample());
+      const selection: Range = {
+        anchor: { path: TWOPATH, offset: 0 }, // "two"
+        focus: { path: THREEPATH, offset: 5 }, // "three"
+      };
+
+      const actual = deleteListFragment(editor, selection);
+
+      expect(actual).toEqual(0);
+      const expected = [
+        {
+          children: [
+            {
+              type: 'p',
+              children: [{ text: 'before' }],
+            },
+            {
+              type: 'ul',
+              children: [
+                {
+                  type: 'li',
+                  children: [
+                    {
+                      type: 'p',
+                      children: [{ text: 'one' }],
+                    },
+                    {
+                      type: 'ul',
+                      children: [
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [{ text: '' }],
+                            },
+                            {
+                              type: 'ul',
+                              children: [
+                                {
+                                  type: 'li',
+                                  children: [
+                                    {
+                                      type: 'p',
+                                      children: [{ text: 'four' }],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'li',
+                          children: [
+                            { type: 'p', children: [{ text: 'five' }] },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'li',
+                  children: [{ type: 'p', children: [{ text: 'six' }] }],
+                },
+              ],
+            },
+            {
+              type: 'p',
+              children: [{ text: 'after' }],
+            },
+          ],
+        },
+      ];
+      expect(editor.children).toEqual(expected);
+
+      // test undo
+      editor.undo();
+
+      const expectedUndo = [createExampleNodes()];
+      expect(editor.children).toEqual(expectedUndo);
+    });
+
+    it('delete moves siblings', () => {
+      const editor = withHistory(createExample());
+      const selection: Range = {
+        anchor: { path: ONEPATH, offset: 1 }, // "one"
+        focus: { path: TWOPATH, offset: 2 }, // "two"
+      };
+
+      const actual = deleteListFragment(editor, selection);
+
+      expect(actual).toEqual(2);
+      const expected = [
+        {
+          children: [
+            {
+              type: 'p',
+              children: [
+                {
+                  text: 'before',
+                },
+              ],
+            },
+            {
+              type: 'ul',
+              children: [
+                {
+                  type: 'li',
+                  children: [
+                    {
+                      type: 'p',
+                      children: [
+                        {
+                          text: 'oo',
+                        },
+                      ],
+                    },
+                    {
+                      type: 'ul',
+                      children: [
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [
+                                {
+                                  text: 'five',
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [
+                                {
+                                  text: 'three',
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'li',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [
+                                {
+                                  text: 'four',
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'li',
+                  children: [
+                    {
+                      type: 'p',
+                      children: [
+                        {
+                          text: 'six',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'p',
+              children: [
+                {
+                  text: 'after',
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      expect(editor.children).toEqual(expected);
+
+      // test undo
+      editor.undo();
+
+      const expectedUndo = [createExampleNodes()];
+      expect(editor.children).toEqual(expectedUndo);
+    });
+  });
+});

--- a/packages/slate-plugins/src/elements/list/queries/getListRoot.ts
+++ b/packages/slate-plugins/src/elements/list/queries/getListRoot.ts
@@ -1,0 +1,27 @@
+import { Ancestor, Editor, NodeEntry, Path, Point, Range } from 'slate';
+import { setDefaults } from '../../../common';
+import { DEFAULTS_LIST } from '../defaults';
+import { ListOptions } from '../types';
+
+/**
+ * Searches upward for the root list element
+ */
+export function getListRoot(
+  editor: Editor,
+  at: Path | Range | Point | null = editor.selection,
+  options?: ListOptions
+): NodeEntry<Ancestor> | undefined {
+  if (!at) {
+    return;
+  }
+
+  const { ol, ul } = setDefaults(options, DEFAULTS_LIST);
+  const list = Editor.above(editor, {
+    at,
+    match: (node) => node.type === ol.type || node.type === ul.type,
+  });
+
+  if (list) {
+    return getListRoot(editor, list[1], options) ?? list;
+  }
+}

--- a/packages/slate-plugins/src/elements/list/queries/isList.ts
+++ b/packages/slate-plugins/src/elements/list/queries/isList.ts
@@ -1,9 +1,9 @@
-import { Node } from 'slate';
+import { Element, Node } from 'slate';
 import { setDefaults } from '../../../common/utils/setDefaults';
 import { DEFAULTS_LIST } from '../defaults';
 import { ListOptions } from '../types';
 
-export const isList = (options?: ListOptions) => (n: Node) => {
+export const isList = (options?: ListOptions) => (n: Node): n is Element => {
   const { ul, ol } = setDefaults(options, DEFAULTS_LIST);
 
   return [ol.type, ul.type].includes(n.type as string);

--- a/packages/slate-plugins/src/elements/list/queries/isSelectionInListItem.ts
+++ b/packages/slate-plugins/src/elements/list/queries/isSelectionInListItem.ts
@@ -1,4 +1,4 @@
-import { Editor } from 'slate';
+import { Editor, Location } from 'slate';
 import { getAboveByType } from '../../../common/queries/getAboveByType';
 import { getParent } from '../../../common/queries/getParent';
 import { isNodeTypeIn } from '../../../common/queries/isNodeTypeIn';
@@ -12,17 +12,20 @@ import { ListOptions } from '../types';
  */
 export const isSelectionInListItem = (
   editor: Editor,
-  options?: ListOptions
+  options?: ListOptions & { at?: Location }
 ) => {
   const { li } = setDefaults(options, DEFAULTS_LIST);
+  const at = options?.at ?? editor.selection;
 
-  if (editor.selection && isNodeTypeIn(editor, li.type)) {
-    const selectionParentEntry = getParent(editor, editor.selection);
+  if (at && isNodeTypeIn(editor, li.type, { at })) {
+    const selectionParentEntry = getParent(editor, at);
     if (!selectionParentEntry) return;
     const [, paragraphPath] = selectionParentEntry;
 
     const listItemEntry =
-      getAboveByType(editor, li.type) || getParent(editor, paragraphPath);
+      getAboveByType(editor, li.type, { at }) ||
+      getParent(editor, paragraphPath);
+
     if (!listItemEntry) return;
     const [listItemNode, listItemPath] = listItemEntry;
 

--- a/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
@@ -1,0 +1,175 @@
+import {
+  Ancestor,
+  Editor,
+  Element,
+  Node,
+  NodeEntry,
+  Path,
+  Range,
+  Transforms,
+} from 'slate';
+import { moveChildren } from '../../../common/transforms/moveChildren';
+import { setDefaults } from '../../../common/utils/setDefaults';
+import { DEFAULTS_LIST } from '../defaults';
+import { isSelectionInListItem } from '../queries';
+import { getListRoot } from '../queries/getListRoot';
+import { ListOptions } from '../types';
+
+function moveChildrenListItems(
+  editor: Editor,
+  listItemNode: Ancestor,
+  listItemPath: Path,
+  targetListPath: Path,
+  {
+    ul = DEFAULTS_LIST.ul,
+    ol = DEFAULTS_LIST.ol,
+    li = DEFAULTS_LIST.li,
+  }: Pick<ListOptions, 'ul' | 'ol' | 'li'>
+): number {
+  if (listItemNode.type !== li.type) return 0;
+
+  let moved = 0;
+
+  for (let i = 0; i < listItemNode.children.length; i++) {
+    const childNode = listItemNode.children[i];
+    if (
+      Editor.isBlock(editor, childNode) &&
+      (childNode.type === ul.type || childNode.type === ol.type)
+    ) {
+      const listPath = [...listItemPath, i];
+      moved +=
+        moveChildren(editor, [childNode, listPath], targetListPath, {
+          pass: ([node]) => node.type === li.type,
+        }) ?? 0;
+      // Remove the empty list
+      Transforms.delete(editor, { at: listPath });
+    }
+  }
+  return moved;
+}
+
+function moveListSiblingsAfterCursor(
+  editor: Editor,
+  cursor: Path,
+  targetPath: Path,
+  {
+    ul = DEFAULTS_LIST.ul,
+    ol = DEFAULTS_LIST.ol,
+  }: Pick<ListOptions, 'ul' | 'ol'>
+): number {
+  const offset = cursor[cursor.length - 1];
+  cursor = Path.parent(cursor);
+  const listNode = Node.get(editor, cursor);
+  const listEntry: NodeEntry = [listNode, cursor];
+  if (
+    (listNode.type !== ul.type && listNode.type !== ol.type) ||
+    Path.isParent(cursor, targetPath) // avoid moving nodes within its own list
+  )
+    return 0;
+
+  const moved =
+    moveChildren(editor, listEntry, targetPath, {
+      start: offset + 1,
+    }) ?? 0;
+  return moved;
+}
+
+export function deleteListFragment(
+  editor: Editor,
+  selection: Range,
+  options: ListOptions = {}
+): number | undefined {
+  const [startSelection, endSelection] = Range.edges(selection);
+  if (Path.equals(startSelection.path, endSelection.path)) return; // only handle deletes across list items
+  const root = getListRoot(editor, endSelection, options);
+  if (!root) return; // end is outside of a list
+  const [rootNode, rootPath] = root;
+  const { li, ul, ol } = setDefaults(options, DEFAULTS_LIST);
+  let moved;
+
+  Editor.withoutNormalizing(editor, () => {
+    const endListResult = isSelectionInListItem(editor, {
+      ...options,
+      at: endSelection,
+    });
+    if (!endListResult) return;
+
+    let next: Path;
+    if (Path.isBefore(startSelection.path, rootPath)) {
+      next = Path.next(rootPath);
+      // we are deleting the top of the list
+      // create a new list to copy list items
+      Transforms.insertNodes(
+        editor,
+        {
+          type: rootNode.type,
+          children: [],
+        },
+        { at: next }
+      );
+      next = [...next, 0];
+    } else {
+      // find the first list item that will not be deleted
+      const startListResult = isSelectionInListItem(editor, {
+        ...options,
+        at: startSelection,
+      });
+      if (!startListResult) return;
+
+      const { listItemNode, listItemPath } = startListResult;
+      const childListIndex = listItemNode.children.findIndex(
+        (node) => node.type === ul.type || node.type === ol.type
+      );
+      if (childListIndex === -1) {
+        // there's no child list to move dangling list items, create one
+        const at = [...listItemPath, listItemNode.children.length];
+        Transforms.insertNodes(
+          editor,
+          {
+            type: rootNode.type,
+            children: [],
+          },
+          { at }
+        );
+        next = [...at, 0];
+      } else {
+        const childList = listItemNode.children[childListIndex] as Element;
+        next = [...listItemPath, childListIndex, childList.children.length];
+      }
+    }
+
+    // move all children into target list
+    const { listItemNode, listItemPath } = endListResult;
+    const childrenMoved = moveChildrenListItems(
+      editor,
+      listItemNode,
+      listItemPath,
+      next,
+      options
+    );
+
+    // move siblings outside of deleted fragment
+    let cursor = endSelection.path;
+    let siblingsMoved = 0;
+    next = [...next.slice(0, -1), next[next.length - 1] + childrenMoved];
+    while (Path.isAfter(cursor, startSelection.path)) {
+      const node = Node.get(editor, cursor);
+      if (node.type === li.type) {
+        siblingsMoved += moveListSiblingsAfterCursor(
+          editor,
+          cursor,
+          next,
+          options
+        );
+      }
+      cursor = Path.parent(cursor);
+    }
+
+    // delete the fragment
+    Transforms.delete(editor, { at: selection });
+
+    moved = siblingsMoved + childrenMoved;
+  });
+
+  return moved;
+}


### PR DESCRIPTION
Resolves #65
Resolves #66

## Issue

When deleting nodes from a list, children and siblings were often unexpectedly deleted. This was because children and siblings of deleted list items would be deleted as part of a hanging node when their parent list was deleted.

## What I did

I added logic to expressly handle children deletions when a delete spanned a list item. Added tests to confirm the fix and also that undo does and will continue to work.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->