### PR TITLE
spread any element attributes on all Element components

### DIFF
--- a/packages/slate-plugins/src/common/types/PluginOptions.types.ts
+++ b/packages/slate-plugins/src/common/types/PluginOptions.types.ts
@@ -32,9 +32,14 @@ export interface RenderNodePropsOptions {
 }
 
 export type DeserializedAttributes = { [key: string]: any } | undefined;
+export type HtmlAttributes = { [key: string]: any } | undefined;
 export type AttributesToProps = (
   attributes: DeserializedAttributes
-) => { [key: string]: any };
+) => HtmlAttributes;
+
+export interface HtmlAttributesProps {
+  htmlAttributes?: HtmlAttributes;
+}
 
 export interface HotkeyOptions {
   /**

--- a/packages/slate-plugins/src/components/StyledComponent/StyledComponent.types.ts
+++ b/packages/slate-plugins/src/components/StyledComponent/StyledComponent.types.ts
@@ -1,7 +1,7 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { RenderElementProps, RenderLeafProps } from 'slate-react';
-import { RenderNodePropsOptions } from '../../common/types/PluginOptions.types';
+import { RenderNodePropsOptions, HtmlAttributesProps } from '../../common/types/PluginOptions.types';
 
 export interface StyledComponentPropsOptions extends RenderNodePropsOptions {
   /**
@@ -19,6 +19,7 @@ export interface StyledComponentPropsOptions extends RenderNodePropsOptions {
 
 export interface StyledElementProps
   extends Omit<StyledComponentProps, 'children'>,
+    HtmlAttributesProps,
     RenderElementProps {}
 
 export interface StyledLeafProps

--- a/packages/slate-plugins/src/components/StyledComponent/StyledComponent.types.ts
+++ b/packages/slate-plugins/src/components/StyledComponent/StyledComponent.types.ts
@@ -1,7 +1,10 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { RenderElementProps, RenderLeafProps } from 'slate-react';
-import { RenderNodePropsOptions, HtmlAttributesProps } from '../../common/types/PluginOptions.types';
+import {
+  HtmlAttributesProps,
+  RenderNodePropsOptions,
+} from '../../common/types/PluginOptions.types';
 
 export interface StyledComponentPropsOptions extends RenderNodePropsOptions {
   /**

--- a/packages/slate-plugins/src/components/StyledComponent/StyledElement.tsx
+++ b/packages/slate-plugins/src/components/StyledComponent/StyledElement.tsx
@@ -32,7 +32,7 @@ export const StyledElementBase = ({
   const Tag = as;
 
   return (
-    <Tag {...attributes} {...htmlAttributes} className={classNames.root}>
+    <Tag {...attributes} className={classNames.root} {...htmlAttributes}>
       {children}
     </Tag>
   );

--- a/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
+++ b/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
@@ -15,7 +15,7 @@ const inlineTags = ['<a href="http://google.com" target="_blank">a</a>'];
 
 const elementTags = [
   '<img alt="removed" src="https://i.imgur.com/removed.png" />',
-  '<table><tr><td colspan="2">table</td></tr></table>',
+  '<table><tr><th colspan="2" scope="row">header</th></tr><tr><td>cell 1</td><td>cell 2</td></tr></table>',
 ];
 
 const html = `<html><body><p>${textTags.join('')}</p><p>${inlineTags.join(
@@ -26,11 +26,7 @@ const input1 = [
   ImagePlugin({
     img: {
       deserialize: {
-        node: (el) => ({
-          type: 'img',
-          url: el.getAttribute('src'),
-          alt: el.getAttribute('alt'),
-        }),
+        attributes: ['alt']
       },
     },
   }),
@@ -47,9 +43,9 @@ const input1 = [
   }),
   ParagraphPlugin(),
   TablePlugin({
-    td: {
+    th: {
       deserialize: {
-        node: (el) => ({ type: 'td', colSpan: el.getAttribute('colspan') }),
+        node: (el) => ({ type: 'th', scope: el.getAttribute('scope') }),
       },
     },
   }),
@@ -71,13 +67,21 @@ const output = (
         a
       </ha>
     </hp>
-    <himg alt="removed" url="https://i.imgur.com/removed.png">
+    <himg url="https://i.imgur.com/removed.png" attributes={{ alt: "removed" }}>
       <htext />
     </himg>
     <htable>
       <htr>
-        <htd colSpan="2" attributes={{ colspan: '2' }}>
-          table
+        <hth scope="row" attributes={{ colspan: '2' }}>
+          header
+        </hth>
+      </htr>
+      <htr>
+        <htd>
+          cell 1
+        </htd>
+        <htd>
+          cell 2
         </htd>
       </htr>
     </htable>

--- a/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
+++ b/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/custom-deserialize.spec.tsx
@@ -26,7 +26,7 @@ const input1 = [
   ImagePlugin({
     img: {
       deserialize: {
-        attributes: ['alt']
+        attributes: ['alt'],
       },
     },
   }),
@@ -67,7 +67,7 @@ const output = (
         a
       </ha>
     </hp>
-    <himg url="https://i.imgur.com/removed.png" attributes={{ alt: "removed" }}>
+    <himg url="https://i.imgur.com/removed.png" attributes={{ alt: 'removed' }}>
       <htext />
     </himg>
     <htable>
@@ -77,12 +77,8 @@ const output = (
         </hth>
       </htr>
       <htr>
-        <htd>
-          cell 1
-        </htd>
-        <htd>
-          cell 2
-        </htd>
+        <htd>cell 1</htd>
+        <htd>cell 2</htd>
       </htr>
     </htable>
   </editor>

--- a/packages/slate-plugins/src/elements/align/types.ts
+++ b/packages/slate-plugins/src/elements/align/types.ts
@@ -2,6 +2,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -21,6 +22,7 @@ export interface AlignRenderElementPropsOptions
 export interface AlignElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     AlignRenderElementPropsOptions {
   element: AlignNode;
 }

--- a/packages/slate-plugins/src/elements/blockquote/components/BlockquoteElement.tsx
+++ b/packages/slate-plugins/src/elements/blockquote/components/BlockquoteElement.tsx
@@ -21,6 +21,7 @@ export const BlockquoteElementBase = ({
   children,
   className,
   styles,
+  htmlAttributes,
 }: BlockquoteElementProps) => {
   const classNames = getClassNames(styles, {
     className,
@@ -28,7 +29,7 @@ export const BlockquoteElementBase = ({
   });
 
   return (
-    <blockquote {...attributes} className={classNames.root}>
+    <blockquote {...attributes} className={classNames.root} {...htmlAttributes}>
       {children}
     </blockquote>
   );

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -4,6 +4,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -30,6 +31,7 @@ export interface BlockquoteRenderElementPropsOptions {
 export interface BlockquoteElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     BlockquoteRenderElementPropsOptions {
   element: BlockquoteNode;
 }

--- a/packages/slate-plugins/src/elements/code-block/components/CodeBlockElement.tsx
+++ b/packages/slate-plugins/src/elements/code-block/components/CodeBlockElement.tsx
@@ -21,6 +21,7 @@ export const CodeBlockElementBase = ({
   children,
   className,
   styles,
+  htmlAttributes,
 }: CodeBlockElementProps) => {
   const classNames = getClassNames(styles, {
     className,
@@ -28,7 +29,7 @@ export const CodeBlockElementBase = ({
   });
 
   return (
-    <pre {...attributes} className={classNames.root}>
+    <pre {...attributes} className={classNames.root} {...htmlAttributes}>
       <code>{children}</code>
     </pre>
   );

--- a/packages/slate-plugins/src/elements/code-block/types.ts
+++ b/packages/slate-plugins/src/elements/code-block/types.ts
@@ -4,6 +4,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -29,6 +30,7 @@ export interface CodeBlockRenderElementPropsOptions {
 export interface CodeBlockElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     CodeBlockRenderElementPropsOptions {
   element: CodeBlockNode;
 }

--- a/packages/slate-plugins/src/elements/heading/types.ts
+++ b/packages/slate-plugins/src/elements/heading/types.ts
@@ -3,6 +3,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -34,6 +35,7 @@ export interface HeadingRenderElementPropsOptions {
 export interface HeadingElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     HeadingRenderElementPropsOptions {
   element: HeadingNode;
 }

--- a/packages/slate-plugins/src/elements/image/components/ImageElement.tsx
+++ b/packages/slate-plugins/src/elements/image/components/ImageElement.tsx
@@ -23,6 +23,7 @@ export const ImageElementBase = ({
   element,
   className,
   styles,
+  htmlAttributes,
 }: ImageElementProps) => {
   const { url } = element;
   const focused = useFocused();
@@ -43,6 +44,7 @@ export const ImageElementBase = ({
           className={classNames.img}
           src={url}
           alt=""
+          {...htmlAttributes}
         />
       </div>
       {children}

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -4,6 +4,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -28,6 +29,7 @@ export interface ImageRenderElementPropsOptions {
 export interface ImageElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     ImageRenderElementPropsOptions {
   element: ImageNode;
 }

--- a/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
+++ b/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
@@ -22,6 +22,7 @@ export const LinkElementBase = ({
   element,
   styles,
   className,
+  htmlAttributes,
 }: LinkElementProps) => {
   const classNames = getClassNames(styles, {
     className,
@@ -29,7 +30,7 @@ export const LinkElementBase = ({
   });
 
   return (
-    <a {...attributes} href={element.url} className={classNames.root}>
+    <a {...attributes} href={element.url} className={classNames.root} {...htmlAttributes}>
       {children}
     </a>
   );

--- a/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
+++ b/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
@@ -30,7 +30,12 @@ export const LinkElementBase = ({
   });
 
   return (
-    <a {...attributes} href={element.url} className={classNames.root} {...htmlAttributes}>
+    <a
+      {...attributes}
+      href={element.url}
+      className={classNames.root}
+      {...htmlAttributes}
+    >
       {children}
     </a>
   );

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -5,6 +5,7 @@ import { RenderElementProps } from 'slate-react';
 import { RangeBeforeOptions } from '../../common/queries/getRangeBefore';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -36,6 +37,7 @@ export interface LinkRenderElementPropsOptions {
 export interface LinkElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     LinkRenderElementPropsOptions {
   element: LinkNode;
 }

--- a/packages/slate-plugins/src/elements/list/types.ts
+++ b/packages/slate-plugins/src/elements/list/types.ts
@@ -3,6 +3,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -38,6 +39,7 @@ export interface ListRenderElementPropsOptions {
 export interface ListElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     ListRenderElementPropsOptions {
   element: ListNode;
 }

--- a/packages/slate-plugins/src/elements/media-embed/components/MediaEmbedElement.tsx
+++ b/packages/slate-plugins/src/elements/media-embed/components/MediaEmbedElement.tsx
@@ -25,6 +25,7 @@ export const MediaEmbedElementBase = ({
   element,
   className,
   styles,
+  htmlAttributes,
 }: MediaEmbedElementProps) => {
   const classNames = getClassNames(styles, {
     className,
@@ -43,6 +44,7 @@ export const MediaEmbedElementBase = ({
             title="embed"
             src={`${url}?title=0&byline=0&portrait=0`}
             frameBorder="0"
+            {...htmlAttributes}
           />
         </div>
 

--- a/packages/slate-plugins/src/elements/media-embed/types.ts
+++ b/packages/slate-plugins/src/elements/media-embed/types.ts
@@ -4,6 +4,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -35,6 +36,7 @@ export interface MediaEmbedRenderElementPropsOptions {
 export interface MediaEmbedElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     MediaEmbedRenderElementPropsOptions {
   element: MediaEmbedNode;
 }

--- a/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
+++ b/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
@@ -25,6 +25,7 @@ export const MentionElementBase = ({
   prefix,
   className,
   styles,
+  htmlAttributes,
   as: Tag = 'span',
   onClick,
 }: MentionElementProps) => {
@@ -45,6 +46,7 @@ export const MentionElementBase = ({
       className={classNames.root}
       contentEditable={false}
       onClick={getHandler(onClick, { value: element.value })}
+      {...htmlAttributes}
     >
       {prefix}
       {element.value}

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -4,6 +4,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -46,6 +47,7 @@ export interface MentionRenderElementPropsOptions {
 export interface MentionElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     MentionRenderElementPropsOptions {
   element: MentionNode;
 }

--- a/packages/slate-plugins/src/elements/paragraph/types.ts
+++ b/packages/slate-plugins/src/elements/paragraph/types.ts
@@ -2,6 +2,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -21,6 +22,7 @@ export interface ParagraphRenderElementPropsOptions
 export interface ParagraphElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     ParagraphRenderElementPropsOptions {
   element: ParagraphNode;
 }

--- a/packages/slate-plugins/src/elements/table/components/TableElement/TableElement.tsx
+++ b/packages/slate-plugins/src/elements/table/components/TableElement/TableElement.tsx
@@ -21,6 +21,7 @@ export const TableElementBase = ({
   children,
   className,
   styles,
+  htmlAttributes,
 }: TableElementProps) => {
   const classNames = getClassNames(styles, {
     className,
@@ -28,7 +29,7 @@ export const TableElementBase = ({
   });
 
   return (
-    <table {...attributes} className={classNames.root}>
+    <table {...attributes} className={classNames.root} {...htmlAttributes}>
       <tbody>{children}</tbody>
     </table>
   );

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -4,6 +4,7 @@ import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -26,6 +27,7 @@ export interface TableRenderElementPropsOptions {
 export interface TableElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     TableRenderElementPropsOptions {
   element: TableNode;
 }

--- a/packages/slate-plugins/src/elements/todo-list/components/TodoListElement.tsx
+++ b/packages/slate-plugins/src/elements/todo-list/components/TodoListElement.tsx
@@ -24,6 +24,7 @@ export const TodoListElementBase = ({
   element,
   className,
   styles,
+  htmlAttributes,
 }: TodoListElementProps) => {
   const editor = useEditor();
   const readOnly = useReadOnly();
@@ -36,7 +37,7 @@ export const TodoListElementBase = ({
   });
 
   return (
-    <div {...attributes} className={classNames.root}>
+    <div {...attributes} className={classNames.root} {...htmlAttributes}>
       <div contentEditable={false} className={classNames.checkboxWrapper}>
         <input
           data-testid="TodoListElementCheckbox"

--- a/packages/slate-plugins/src/elements/todo-list/types.ts
+++ b/packages/slate-plugins/src/elements/todo-list/types.ts
@@ -3,6 +3,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  HtmlAttributesProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -34,6 +35,7 @@ export interface TodoListRenderElementPropsOptions {
 export interface TodoListElementProps
   extends RenderElementProps,
     RenderNodePropsOptions,
+    HtmlAttributesProps,
     TodoListRenderElementPropsOptions {
   element: TodoListNode;
 }

--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/elements.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/elements.spec.ts
@@ -160,7 +160,7 @@ it('serialize table to html', () => {
   expect(render.children[0].children[0].children[0].textContent).toEqual('Foo');
   expect(render.children[0].children[0].children[1].textContent).toEqual('Bar');
   expect(render.children[0]?.children[1].children[0].outerHTML).toEqual(
-    '<td colspan="2" class="slate-td">Span</td>'
+    '<td class="slate-td" colspan="2">Span</td>'
   );
 });
 

--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-attributes.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-attributes.spec.ts
@@ -1,0 +1,45 @@
+import {
+  htmlStringToDOMNode,
+  ImagePlugin,
+  LinkPlugin,
+} from '../../../index';
+import { serializeHTMLFromNodes } from '../index';
+
+it('serialize link to html with attributes', () => {
+  expect(
+    serializeHTMLFromNodes({
+      plugins: [LinkPlugin()],
+      nodes: [
+        { text: 'Some paragraph of text with ' },
+        {
+          type: 'a',
+          url: 'https://theuselessweb.com/',
+          attributes: { target: '_blank', rel: 'noopener nofollow' },
+          children: [{ text: 'link' }],
+        },
+        { text: ' part.' },
+      ],
+    })
+  ).toBe(
+    'Some paragraph of text with <a href="https://theuselessweb.com/" class="slate-link" target="_blank" rel="noopener nofollow">link</a> part.'
+  );
+});
+
+it('serialize image with alt to html', () => {
+  expect(
+    htmlStringToDOMNode(
+      serializeHTMLFromNodes({
+        plugins: [ImagePlugin()],
+        nodes: [
+          {
+            type: 'img',
+            url:
+              'https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg',
+            attributes: { alt: 'Never gonna give you up' },
+            children: [],
+          },
+        ],
+      })
+    ).getElementsByTagName('img')[0].outerHTML
+  ).toEqual('<img src="https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg" alt="Never gonna give you up">');
+});

--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-attributes.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-attributes.spec.ts
@@ -1,8 +1,4 @@
-import {
-  htmlStringToDOMNode,
-  ImagePlugin,
-  LinkPlugin,
-} from '../../../index';
+import { htmlStringToDOMNode, ImagePlugin, LinkPlugin } from '../../../index';
 import { serializeHTMLFromNodes } from '../index';
 
 it('serialize link to html with attributes', () => {
@@ -41,5 +37,7 @@ it('serialize image with alt to html', () => {
         ],
       })
     ).getElementsByTagName('img')[0].outerHTML
-  ).toEqual('<img src="https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg" alt="Never gonna give you up">');
+  ).toEqual(
+    '<img src="https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg" alt="Never gonna give you up">'
+  );
 });


### PR DESCRIPTION
## Issue

When you specify attributes for deserialization (for instance `img { deserialize { attributes: ['alt'] } }`), those captured attributes are not rendered / serialized by default, requiring a custom component to extract them from the `htmlAttributes` prop provided by `getRenderElement`

## What I did

Included the `htmlAttributes` prop on all element components, so no additional custom component is needed in these cases.  This is in regards to this slack conversation: https://slate-js.slack.com/archives/C013QHXSCG1/p1605138123156100?thread_ts=1605113240.155700&cid=C013QHXSCG1

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->