### PR TITLE
alternative to attributesToProps that provides more context

### DIFF
--- a/packages/slate-plugins/src/common/types/PluginOptions.types.ts
+++ b/packages/slate-plugins/src/common/types/PluginOptions.types.ts
@@ -56,7 +56,7 @@ export interface NodeToProps<
   RootPropsType = RenderNodePropsOptions & { [key: string]: any }
 > {
   /**
-   * Function to evaluate a node and return props
+   * Function to evaluate a node's attributes, element, children, and rootProps to generate new props
    */
   nodeToProps?: (
     options: NodeToPropsOptions<ElementType, RootPropsType>

--- a/packages/slate-plugins/src/common/types/PluginOptions.types.ts
+++ b/packages/slate-plugins/src/common/types/PluginOptions.types.ts
@@ -1,3 +1,5 @@
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
 import {
   GetElementDeserializerOptions,
   GetLeafDeserializerOptions,
@@ -24,18 +26,30 @@ export interface RenderNodePropsOptions {
   className?: string;
 
   as?: any;
-
-  /**
-   * Function to evaluate any stored attributes on the element and return as props
-   */
-  attributesToProps?: AttributesToProps;
 }
 
 export type DeserializedAttributes = { [key: string]: any } | undefined;
+
+export interface ElementWithAttributes extends Element {
+  attributes?: DeserializedAttributes;
+}
+
+export interface RenderElementPropsWithAttributes extends RenderElementProps {
+  element: ElementWithAttributes;
+}
+
+export interface NodeToPropsOptions
+  extends RenderElementPropsWithAttributes,
+    RootProps<RenderNodePropsOptions> {}
+
+export interface NodeToProps<T> {
+  /**
+   * Function to evaluate a node and return props
+   */
+  nodeToProps?: (options: T) => HtmlAttributes;
+}
+
 export type HtmlAttributes = { [key: string]: any } | undefined;
-export type AttributesToProps = (
-  attributes: DeserializedAttributes
-) => HtmlAttributes;
 
 export interface HtmlAttributesProps {
   htmlAttributes?: HtmlAttributes;

--- a/packages/slate-plugins/src/common/types/PluginOptions.types.ts
+++ b/packages/slate-plugins/src/common/types/PluginOptions.types.ts
@@ -38,15 +38,29 @@ export interface RenderElementPropsWithAttributes extends RenderElementProps {
   element: ElementWithAttributes;
 }
 
-export interface NodeToPropsOptions
-  extends RenderElementPropsWithAttributes,
-    RootProps<RenderNodePropsOptions> {}
+export interface ElementNode<T = Element> {
+  element: T;
+}
 
-export interface NodeToProps<T> {
+export interface NodeToPropsOptions<
+  ElementType = Element,
+  RootPropsType = RenderNodePropsOptions
+>
+  extends Omit<RenderElementPropsWithAttributes, 'element'>,
+    RootProps<RootPropsType> {
+  element: ElementType;
+}
+
+export interface NodeToProps<
+  ElementType = Element & { [key: string]: any },
+  RootPropsType = RenderNodePropsOptions & { [key: string]: any }
+> {
   /**
    * Function to evaluate a node and return props
    */
-  nodeToProps?: (options: T) => HtmlAttributes;
+  nodeToProps?: (
+    options: NodeToPropsOptions<ElementType, RootPropsType>
+  ) => HtmlAttributes;
 }
 
 export type HtmlAttributes = { [key: string]: any } | undefined;

--- a/packages/slate-plugins/src/common/utils/getRenderElement.tsx
+++ b/packages/slate-plugins/src/common/utils/getRenderElement.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import pickBy from 'lodash/pickBy';
 import {
   NodeToProps,
-  NodeToPropsOptions,
   RenderElementPropsWithAttributes,
   RenderNodeOptions,
 } from '../types/PluginOptions.types';
 
 export interface GetRenderElementOptions
   extends Required<RenderNodeOptions>,
-    NodeToProps<NodeToPropsOptions> {}
+    NodeToProps<any, any> {}
 
 /**
  * Get a `renderElement` handler for a single type.

--- a/packages/slate-plugins/src/common/utils/getRenderElement.tsx
+++ b/packages/slate-plugins/src/common/utils/getRenderElement.tsx
@@ -1,50 +1,15 @@
 import * as React from 'react';
 import pickBy from 'lodash/pickBy';
-import { Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import {
-  AttributesToProps,
-  DeserializedAttributes,
+  NodeToProps,
+  NodeToPropsOptions,
+  RenderElementPropsWithAttributes,
   RenderNodeOptions,
 } from '../types/PluginOptions.types';
 
-export interface GetRenderElementOptions {
-  /**
-   * Type of the element.
-   */
-  type: string;
-  /**
-   * React component to render the element.
-   */
-  component: any;
-
-  /**
-   * Options passed to the component as props.
-   */
-  [key: string]: any;
-}
-
-export interface ElementWithAttributes extends Element {
-  attributes?: DeserializedAttributes;
-}
-
-export interface RenderElementPropsWithAttributes extends RenderElementProps {
-  element: ElementWithAttributes;
-}
-
-export interface GetHtmlAttributes {
-  attributes?: DeserializedAttributes;
-  attributesToProps?: AttributesToProps;
-}
-
-const getHtmlAttributes = ({
-  attributes,
-  attributesToProps,
-}: GetHtmlAttributes) => {
-  if (attributes && attributesToProps)
-    return pickBy(attributesToProps(attributes));
-  if (attributes) return pickBy(attributes);
-};
+export interface GetRenderElementOptions
+  extends Required<RenderNodeOptions>,
+    NodeToProps<NodeToPropsOptions> {}
 
 /**
  * Get a `renderElement` handler for a single type.
@@ -55,23 +20,25 @@ export const getRenderElement = ({
   type,
   component: Component,
   rootProps,
-}: Required<RenderNodeOptions>) => ({
+  nodeToProps,
+}: GetRenderElementOptions) => ({
   attributes,
-  ...props
+  element,
+  children,
 }: RenderElementPropsWithAttributes) => {
-  if (props.element.type === type) {
-    const htmlAttributes = getHtmlAttributes({
-      attributes: props.element?.attributes,
-      attributesToProps: rootProps?.attributesToProps,
-    });
-
+  if (element.type === type) {
+    const htmlAttributes =
+      nodeToProps?.({ attributes, element, children, rootProps }) ??
+      element?.attributes;
     return (
       <Component
         attributes={attributes}
         htmlAttributes={htmlAttributes}
-        {...props}
+        element={element}
         {...pickBy(rootProps)}
-      />
+      >
+        {children}
+      </Component>
     );
   }
 };
@@ -79,18 +46,21 @@ export const getRenderElement = ({
 /**
  * Get a `renderElement` handler for multiple types.
  */
-export const getRenderElements = (options: Required<RenderNodeOptions>[]) => ({
+export const getRenderElements = (options: GetRenderElementOptions[]) => ({
   attributes,
   element,
   children,
 }: RenderElementPropsWithAttributes) => {
-  for (const { type, component: Component, rootProps } of options) {
+  for (const {
+    type,
+    component: Component,
+    rootProps,
+    nodeToProps,
+  } of options) {
     if (element.type === type) {
-      const htmlAttributes = getHtmlAttributes({
-        attributes: element?.attributes,
-        attributesToProps: rootProps?.attributesToProps,
-      });
-
+      const htmlAttributes =
+        nodeToProps?.({ attributes, element, children, rootProps }) ??
+        element?.attributes;
       return (
         <Component
           attributes={attributes}

--- a/packages/slate-plugins/src/elements/align/types.ts
+++ b/packages/slate-plugins/src/elements/align/types.ts
@@ -1,8 +1,9 @@
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -12,7 +13,7 @@ import { StyledComponentPropsOptions } from '../../components/StyledComponent/St
 // Data of Element node
 export interface AlignNodeData {}
 // Element node
-export interface AlignNode extends Element {}
+export interface AlignNode extends ElementWithAttributes, AlignNodeData {}
 
 // renderElement options given as props
 export interface AlignRenderElementPropsOptions
@@ -32,6 +33,7 @@ export type AlignKeyOption = 'align_left' | 'align_center' | 'align_right';
 // Plugin options
 export type AlignPluginOptionsValues = RenderNodeOptions &
   RootProps<AlignRenderElementPropsOptions> &
+  NodeToProps<AlignNode, AlignRenderElementPropsOptions> &
   Deserialize;
 export type AlignPluginOptionsKeys = keyof AlignPluginOptionsValues;
 export type AlignPluginOptions<

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -1,10 +1,11 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -14,7 +15,9 @@ import {
 export interface BlockquoteNodeData {}
 
 // Element node
-export interface BlockquoteNode extends Element, BlockquoteNodeData {}
+export interface BlockquoteNode
+  extends ElementWithAttributes,
+    BlockquoteNodeData {}
 
 // renderElement options given as props
 export interface BlockquoteRenderElementPropsOptions {
@@ -41,6 +44,7 @@ export type BlockquoteKeyOption = 'blockquote';
 // Plugin options
 export type BlockquotePluginOptionsValues = RenderNodeOptions &
   RootProps<BlockquoteRenderElementPropsOptions> &
+  NodeToProps<BlockquoteNode, BlockquoteRenderElementPropsOptions> &
   Deserialize;
 export type BlockquotePluginOptionsKeys = keyof BlockquotePluginOptionsValues;
 export type BlockquotePluginOptions<

--- a/packages/slate-plugins/src/elements/code-block/types.ts
+++ b/packages/slate-plugins/src/elements/code-block/types.ts
@@ -1,10 +1,11 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -13,7 +14,9 @@ import {
 // Data of Element node
 export interface CodeBlockNodeData {}
 // Element node
-export interface CodeBlockNode extends Element, CodeBlockNodeData {}
+export interface CodeBlockNode
+  extends ElementWithAttributes,
+    CodeBlockNodeData {}
 
 // renderElement options given as props
 export interface CodeBlockRenderElementPropsOptions {
@@ -40,6 +43,7 @@ export type CodeBlockKeyOption = 'code_block';
 // Plugin options
 export type CodeBlockPluginOptionsValues = RenderNodeOptions &
   RootProps<CodeBlockRenderElementPropsOptions> &
+  NodeToProps<CodeBlockNode, CodeBlockRenderElementPropsOptions> &
   Deserialize;
 export type CodeBlockPluginOptionsKeys = keyof CodeBlockPluginOptionsValues;
 export type CodeBlockPluginOptions<

--- a/packages/slate-plugins/src/elements/heading/types.ts
+++ b/packages/slate-plugins/src/elements/heading/types.ts
@@ -1,9 +1,10 @@
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -16,7 +17,7 @@ import {
 // Data of Element node
 export interface HeadingNodeData {}
 // Element node
-export interface HeadingNode extends Element, HeadingNodeData {}
+export interface HeadingNode extends ElementWithAttributes, HeadingNodeData {}
 
 // renderElement options given as props
 export interface HeadingRenderElementPropsOptions {
@@ -52,6 +53,7 @@ export type HeadingKeyOption = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 // Plugin options
 export type HeadingPluginOptionsValues = RenderNodeOptions &
   RootProps<HeadingRenderElementPropsOptions> &
+  NodeToProps<HeadingNode, HeadingRenderElementPropsOptions> &
   Deserialize;
 export type HeadingPluginOptionsKeys = keyof HeadingPluginOptionsValues;
 export type HeadingPluginOptions<

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -1,10 +1,11 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -15,7 +16,7 @@ export interface ImageNodeData {
   url: string;
 }
 // Element node
-export interface ImageNode extends Element, ImageNodeData {}
+export interface ImageNode extends ElementWithAttributes, ImageNodeData {}
 
 // renderElement options given as props
 export interface ImageRenderElementPropsOptions {
@@ -39,6 +40,7 @@ export type ImageKeyOption = 'img';
 // Plugin options
 export type ImagePluginOptionsValues = RenderNodeOptions &
   RootProps<ImageRenderElementPropsOptions> &
+  NodeToProps<ImageNode, ImageRenderElementPropsOptions> &
   Deserialize;
 export type ImagePluginOptionsKeys = keyof ImagePluginOptionsValues;
 export type ImagePluginOptions<

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -1,11 +1,14 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import { RangeBeforeOptions } from '../../common/queries/getRangeBefore';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
+  NodeToPropsOptions,
+  RenderElementPropsWithAttributes,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -20,7 +23,12 @@ export interface LinkNodeData {
   url: string;
 }
 // Element node
-export interface LinkNode extends Element, LinkNodeData {}
+export interface LinkNode extends ElementWithAttributes, LinkNodeData {}
+
+export type LinkNodeToPropsOptions = NodeToPropsOptions &
+  RootProps<LinkRenderElementPropsOptions> & {
+    element: LinkNode;
+  };
 
 // renderElement options given as props
 export interface LinkRenderElementPropsOptions {
@@ -47,6 +55,7 @@ export type LinkKeyOption = 'link';
 // Plugin options
 export type LinkPluginOptionsValues = RenderNodeOptions &
   RootProps<LinkRenderElementPropsOptions> &
+  NodeToProps<LinkNodeToPropsOptions> &
   Deserialize & {
     /**
      * Callback to validate an url.

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -7,8 +7,6 @@ import {
   ElementWithAttributes,
   HtmlAttributesProps,
   NodeToProps,
-  NodeToPropsOptions,
-  RenderElementPropsWithAttributes,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -24,11 +22,6 @@ export interface LinkNodeData {
 }
 // Element node
 export interface LinkNode extends ElementWithAttributes, LinkNodeData {}
-
-export type LinkNodeToPropsOptions = NodeToPropsOptions &
-  RootProps<LinkRenderElementPropsOptions> & {
-    element: LinkNode;
-  };
 
 // renderElement options given as props
 export interface LinkRenderElementPropsOptions {
@@ -55,7 +48,7 @@ export type LinkKeyOption = 'link';
 // Plugin options
 export type LinkPluginOptionsValues = RenderNodeOptions &
   RootProps<LinkRenderElementPropsOptions> &
-  NodeToProps<LinkNodeToPropsOptions> &
+  NodeToProps<LinkNode, LinkRenderElementPropsOptions> &
   Deserialize & {
     /**
      * Callback to validate an url.
@@ -70,7 +63,9 @@ export type LinkPluginOptions<
 // renderElement options
 export type LinkRenderElementOptionsKeys = LinkPluginOptionsKeys;
 export interface LinkRenderElementOptions
-  extends LinkPluginOptions<'type' | 'component' | 'rootProps'> {}
+  extends LinkPluginOptions<
+    'type' | 'component' | 'rootProps' | 'nodeToProps'
+  > {}
 
 // deserialize options
 export interface LinkDeserializeOptions

--- a/packages/slate-plugins/src/elements/list/types.ts
+++ b/packages/slate-plugins/src/elements/list/types.ts
@@ -1,9 +1,10 @@
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -22,7 +23,7 @@ export const ListHotkey = {
 // Data of Element node
 export interface ListNodeData {}
 // Element node
-export interface ListNode extends Element, ListNodeData {}
+export interface ListNode extends ElementWithAttributes, ListNodeData {}
 
 // renderElement options given as props
 export interface ListRenderElementPropsOptions {
@@ -49,6 +50,7 @@ export type ListKeyOption = 'ul' | 'ol' | 'li' | 'p';
 // Plugin options
 export type ListPluginOptionsValues = RenderNodeOptions &
   RootProps<ListRenderElementPropsOptions> &
+  NodeToProps<ListNode, ListRenderElementPropsOptions> &
   Deserialize;
 export type ListPluginOptionsKeys = keyof ListPluginOptionsValues;
 export type ListPluginOptions<

--- a/packages/slate-plugins/src/elements/media-embed/types.ts
+++ b/packages/slate-plugins/src/elements/media-embed/types.ts
@@ -1,10 +1,11 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -19,7 +20,9 @@ export interface MediaEmbedNodeData {
   url: string;
 }
 // Element node
-export interface MediaEmbedNode extends Element, MediaEmbedNodeData {}
+export interface MediaEmbedNode
+  extends ElementWithAttributes,
+    MediaEmbedNodeData {}
 
 // renderElement options given as props
 export interface MediaEmbedRenderElementPropsOptions {
@@ -46,6 +49,7 @@ export type MediaEmbedKeyOption = 'media_embed';
 // Plugin options
 export type MediaEmbedPluginOptionsValues = RenderNodeOptions &
   RootProps<MediaEmbedRenderElementPropsOptions> &
+  NodeToProps<MediaEmbedNode, MediaEmbedRenderElementPropsOptions> &
   Deserialize;
 export type MediaEmbedPluginOptionsKeys = keyof MediaEmbedPluginOptionsValues;
 export type MediaEmbedPluginOptions<

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -1,10 +1,11 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -24,7 +25,7 @@ export interface MentionNodeData {
   [key: string]: any;
 }
 // Element node
-export interface MentionNode extends Element, MentionNodeData {}
+export interface MentionNode extends ElementWithAttributes, MentionNodeData {}
 
 // renderElement options given as props
 export interface MentionRenderElementPropsOptions {
@@ -57,6 +58,7 @@ export type MentionKeyOption = 'mention';
 // Plugin options
 export type MentionPluginOptionsValues = RenderNodeOptions &
   RootProps<MentionRenderElementPropsOptions> &
+  NodeToProps<MentionNode, MentionRenderElementPropsOptions> &
   Deserialize;
 export type MentionPluginOptionsKeys = keyof MentionPluginOptionsValues;
 export type MentionPluginOptions<

--- a/packages/slate-plugins/src/elements/paragraph/types.ts
+++ b/packages/slate-plugins/src/elements/paragraph/types.ts
@@ -1,8 +1,9 @@
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -12,7 +13,9 @@ import { StyledComponentPropsOptions } from '../../components/StyledComponent/St
 // Data of Element node
 export interface ParagraphNodeData {}
 // Element node
-export interface ParagraphNode extends Element, ParagraphNodeData {}
+export interface ParagraphNode
+  extends ElementWithAttributes,
+    ParagraphNodeData {}
 
 // renderElement options given as props
 export interface ParagraphRenderElementPropsOptions
@@ -32,6 +35,7 @@ export type ParagraphKeyOption = 'p';
 // Plugin options
 export type ParagraphPluginOptionsValues = RenderNodeOptions &
   RootProps<ParagraphRenderElementPropsOptions> &
+  NodeToProps<ParagraphNode, ParagraphRenderElementPropsOptions> &
   Deserialize;
 export type ParagraphPluginOptionsKeys = keyof ParagraphPluginOptionsValues;
 export type ParagraphPluginOptions<

--- a/packages/slate-plugins/src/elements/table/defaults.ts
+++ b/packages/slate-plugins/src/elements/table/defaults.ts
@@ -33,10 +33,6 @@ export const DEFAULTS_TABLE: Record<
     rootProps: {
       className: 'slate-th',
       as: 'th',
-      attributesToProps: (attributes) => ({
-        colSpan: attributes?.['colspan'],
-        rowSpan: attributes?.['rowspan'],
-      }),
       styles: {
         root: {
           backgroundColor: 'rgb(244, 245, 247)',
@@ -52,6 +48,10 @@ export const DEFAULTS_TABLE: Record<
         },
       },
     },
+    nodeToProps: ({ element }) => ({
+      colSpan: element?.attributes?.['colspan'],
+      rowSpan: element?.attributes?.['rowspan'],
+    }),
   },
   td: {
     component: StyledElement,
@@ -59,10 +59,6 @@ export const DEFAULTS_TABLE: Record<
     rootProps: {
       className: 'slate-td',
       as: 'td',
-      attributesToProps: (attributes) => ({
-        colSpan: attributes?.['colspan'],
-        rowSpan: attributes?.['rowspan'],
-      }),
       styles: {
         root: {
           backgroundColor: 'rgb(255, 255, 255)',
@@ -77,5 +73,9 @@ export const DEFAULTS_TABLE: Record<
         },
       },
     },
+    nodeToProps: ({ element }) => ({
+      colSpan: element?.attributes?.['colspan'],
+      rowSpan: element?.attributes?.['rowspan'],
+    }),
   },
 };

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -1,10 +1,12 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
+  NodeToPropsOptions,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -13,7 +15,12 @@ import {
 // Data of Element node
 export interface TableNodeData {}
 // Element node
-export interface TableNode extends Element, TableNodeData {}
+export interface TableNode extends ElementWithAttributes, TableNodeData {}
+
+export type TableNodeToPropsOptions = NodeToPropsOptions &
+  RootProps<TableRenderElementPropsOptions> & {
+    element: TableNode;
+  };
 
 // renderElement options given as props
 export interface TableRenderElementPropsOptions {
@@ -37,6 +44,7 @@ export type TableKeyOption = 'table' | 'th' | 'tr' | 'td';
 // Plugin options
 export type TablePluginOptionsValues = RenderNodeOptions &
   RootProps<TableRenderElementPropsOptions> &
+  NodeToProps<TableNodeToPropsOptions> &
   Deserialize;
 export type TablePluginOptionsKeys = keyof TablePluginOptionsValues;
 export type TablePluginOptions<

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -6,7 +6,6 @@ import {
   ElementWithAttributes,
   HtmlAttributesProps,
   NodeToProps,
-  NodeToPropsOptions,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -16,11 +15,6 @@ import {
 export interface TableNodeData {}
 // Element node
 export interface TableNode extends ElementWithAttributes, TableNodeData {}
-
-export type TableNodeToPropsOptions = NodeToPropsOptions &
-  RootProps<TableRenderElementPropsOptions> & {
-    element: TableNode;
-  };
 
 // renderElement options given as props
 export interface TableRenderElementPropsOptions {
@@ -44,7 +38,7 @@ export type TableKeyOption = 'table' | 'th' | 'tr' | 'td';
 // Plugin options
 export type TablePluginOptionsValues = RenderNodeOptions &
   RootProps<TableRenderElementPropsOptions> &
-  NodeToProps<TableNodeToPropsOptions> &
+  NodeToProps<TableNode, TableRenderElementPropsOptions> &
   Deserialize;
 export type TablePluginOptionsKeys = keyof TablePluginOptionsValues;
 export type TablePluginOptions<

--- a/packages/slate-plugins/src/elements/todo-list/types.ts
+++ b/packages/slate-plugins/src/elements/todo-list/types.ts
@@ -1,9 +1,10 @@
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import {
+  ElementWithAttributes,
   HtmlAttributesProps,
+  NodeToProps,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -18,7 +19,7 @@ export interface TodoListNodeData {
   checked?: boolean;
 }
 // Element node
-export interface TodoListNode extends Element, TodoListNodeData {}
+export interface TodoListNode extends ElementWithAttributes, TodoListNodeData {}
 
 // renderElement options given as props
 export interface TodoListRenderElementPropsOptions {
@@ -44,7 +45,8 @@ export type TodoListKeyOption = 'todo_li';
 
 // Plugin options
 export type TodoListPluginOptionsValues = RenderNodeOptions &
-  RootProps<TodoListRenderElementPropsOptions>;
+  RootProps<TodoListRenderElementPropsOptions> &
+  NodeToProps<TodoListNode, TodoListRenderElementPropsOptions>;
 export type TodoListPluginOptionsKeys = keyof TodoListPluginOptionsValues;
 export type TodoListPluginOptions<
   Value extends TodoListPluginOptionsKeys = TodoListPluginOptionsKeys

--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/node-to-props.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/node-to-props.spec.ts
@@ -1,0 +1,36 @@
+import { htmlStringToDOMNode, ImagePlugin, LinkPlugin } from '../../../index';
+import { serializeHTMLFromNodes } from '../index';
+
+it('serialize link to html with attributes', () => {
+  expect(
+    serializeHTMLFromNodes({
+      plugins: [
+        LinkPlugin({
+          link: {
+            nodeToProps: ({ element }) =>
+              /^https?:\/\/slatejs.org\/?/.test(element.url)
+                ? {}
+                : { target: '_blank' },
+          },
+        }),
+      ],
+      nodes: [
+        { text: 'An external ' },
+        {
+          type: 'a',
+          url: 'https://theuselessweb.com/',
+          children: [{ text: 'link' }],
+        },
+        { text: ' and an internal ' },
+        {
+          type: 'a',
+          url: 'https://slatejs.org/',
+          children: [{ text: 'link' }],
+        },
+        { text: '.' },
+      ],
+    })
+  ).toBe(
+    'An external <a href="https://theuselessweb.com/" class="slate-link" target="_blank">link</a> and an internal <a href="https://slatejs.orf/" class="slate-link">link</a>.'
+  );
+});

--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/node-to-props.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/node-to-props.spec.ts
@@ -31,6 +31,35 @@ it('serialize link to html with attributes', () => {
       ],
     })
   ).toBe(
-    'An external <a href="https://theuselessweb.com/" class="slate-link" target="_blank">link</a> and an internal <a href="https://slatejs.orf/" class="slate-link">link</a>.'
+    'An external <a href="https://theuselessweb.com/" class="slate-link" target="_blank">link</a> and an internal <a href="https://slatejs.org/" class="slate-link">link</a>.'
+  );
+});
+
+it('serialize image with alt to html', () => {
+  expect(
+    htmlStringToDOMNode(
+      serializeHTMLFromNodes({
+        plugins: [
+          ImagePlugin({
+            img: {
+              nodeToProps: ({ element }) => ({
+                width: element.url.split('/').pop(),
+                alt: element.attributes?.alt,
+              }),
+            },
+          }),
+        ],
+        nodes: [
+          {
+            type: 'img',
+            url: 'https://via.placeholder.com/300',
+            attributes: { alt: 'Placeholder' },
+            children: [],
+          },
+        ],
+      })
+    ).getElementsByTagName('img')[0].outerHTML
+  ).toEqual(
+    '<img src="https://via.placeholder.com/300" alt="Placeholder" width="300">'
   );
 });


### PR DESCRIPTION
## Issue

When adding `attributesToProps`, I was focused on the use case of formatting deserialized attributes in a way React wouldn't complain (eg. `colspan` attribute -> `colSpan` prop).  But there's a lot more potential here.  Rather than constraining the `attributesToProps` to only reference `element.attributes` it might also be great to look at `element.url` for a link element, or whatever custom node data one might add.  Additionally it might be helpful to introspect the slate `attributes`, the node's `children` and even `rootProps`.

## What I did

I am replacing `attributesToProps(attributes)` with `nodeToProps({ attributes, element, children, rootProps })`.  I also moved this optional function out from `rootProps` to the parent object since it doesn't feel like it belongs inside `rootProps`.  I updated the td / th use of `attributeToProps` -> `nodeToProps`

My intention is to add `nodeToProps` support to all elements, but I'm having a bit of typescript trouble with my test case with the link plugin.  In my proof of concept I am testing the `element.url` to determine if I should add a `{ target: '_blank' }` prop, but I can't get `renderElementLink` to agree on the types defined in link/types vs what is defined in `GetRenderElementOptions`.  Do you have any suggestions making `GetRenderElementOptions` to cooperate with `NodeToProps<LinkNodeToPropsOptions>`?

Also, I'm not 100% sold on `nodeToProps` as a name, so if you have any better suggestions I'd be happy to change it.  `getDerivedPropsForNode` or `addProps`?

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->