### PR TITLE
feat: externalized styled-components so it's not inclued in the bundle

### DIFF
--- a/packages/slate-plugins/package.json
+++ b/packages/slate-plugins/package.json
@@ -47,7 +47,8 @@
     "react-dom": "*",
     "slate": ">=0.58.0",
     "slate-hyperscript": ">=0.58.0",
-    "slate-react": ">=0.58.0"
+    "slate-react": ">=0.58.0",
+    "styled-components": "^5.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Issue
As a side effect of removing styled-components from peerDependencies in [0.62.0 release](https://github.com/udecode/slate-plugins/pull/206), styled-components library is no longer added to externals in the [rollbar config](https://github.com/udecode/slate-plugins/blob/next/rollup.config.js#L9) which in turn results in the whole styled-components 5.1.1 being bundled into `slate-plugins/packages/slate-plugins/dist/index.js`.

Styled components being a singleton library expects only one instance being created.

When bundling a project that depends on both styled-components@5.1.1 and @udecode/slate-plugins we're seeing 2 separate instances of styled components 5.1.1 in our bundle. This issue disappears when externalizing styled-components in the rollup config in @udecode/slate-plugins.

## What I did
Added styled-components to peerDependencies so it's then added to externals in rollbar config.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->