### PR TITLE
feat: remove styled components from bundle

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,36 @@ module.exports = {
   },
   overrides: [
     {
+      files: 'packages/**/*',
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: '@styled-icons',
+                message:
+                  '@styled-icons package is meant to be used in stories only',
+              },
+            ],
+            // The no-restricted-imports rule does not support custom messages for pattern imports yet: https://github.com/eslint/eslint/issues/11843
+            patterns: ['@styled-icons/*'],
+          },
+        ],
+      },
+    },
+    {
+      files: 'packages/**/__tests__/*',
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [],
+          },
+        ],
+      },
+    },
+    {
       files: '**/*.stories.tsx',
       rules: {
         // just for showing the code in addon-docs

--- a/packages/slate-plugins/src/dnd/components/Selectable.styles.ts
+++ b/packages/slate-plugins/src/dnd/components/Selectable.styles.ts
@@ -64,11 +64,6 @@ export const getSelectableStyles = ({
       overflow: 'hidden',
       outline: 'none',
     },
-    dragIcon: {
-      width: 18,
-      height: 18,
-      color: 'rgba(55, 53, 47, 0.3)',
-    },
     dropLine: {
       position: 'absolute',
       left: 0,

--- a/packages/slate-plugins/src/dnd/components/Selectable.tsx
+++ b/packages/slate-plugins/src/dnd/components/Selectable.tsx
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react';
 import useMergedRef from '@react-hook/merged-ref';
-import { DragIndicator } from '@styled-icons/material/DragIndicator';
 import Tippy from '@tippyjs/react';
 import { mergeStyles } from '@uifabric/styling';
 import { classNamesFunction, styled } from '@uifabric/utilities';
@@ -24,6 +23,7 @@ const SelectableBase = ({
   className,
   styles,
   componentRef,
+  dragIcon,
 }: SelectableProps) => {
   const blockRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -72,7 +72,7 @@ const SelectableBase = ({
                   className={classNames.dragButton}
                   onMouseDown={(e: any) => e.stopPropagation()}
                 >
-                  <DragIndicator className={classNames.dragIcon} />
+                  {dragIcon}
                 </button>
               </div>
             </Tippy>

--- a/packages/slate-plugins/src/dnd/components/Selectable.types.ts
+++ b/packages/slate-plugins/src/dnd/components/Selectable.types.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { Element } from 'slate';
@@ -22,6 +23,8 @@ export interface SelectableProps
   children?: any;
 
   componentRef?: any;
+
+  dragIcon?: React.ReactNode;
 
   element: ElementWithId;
 }

--- a/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
+++ b/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
@@ -20,6 +20,7 @@ export interface GetSelectabelElementOptions {
   level?: number;
   filter?: (editor: Editor, path: Path) => boolean;
   allowReadOnly?: boolean;
+  dragIcon?: React.ReactNode;
 }
 
 export const getSelectableElement = ({
@@ -28,6 +29,7 @@ export const getSelectableElement = ({
   level,
   filter,
   allowReadOnly = false,
+  dragIcon,
 }: GetSelectabelElementOptions) => {
   return forwardRef(
     ({ attributes, element, ...props }: RenderElementProps, ref) => {
@@ -54,6 +56,7 @@ export const getSelectableElement = ({
           componentRef={ref}
           element={element as ElementWithId}
           styles={styles}
+          dragIcon={dragIcon}
         >
           <Component attributes={attributes} element={element} {...props} />
         </Selectable>

--- a/stories/examples/dnd.stories.tsx
+++ b/stories/examples/dnd.stories.tsx
@@ -27,6 +27,7 @@ import {
   LooksTwo,
   Search,
 } from '@styled-icons/material';
+import { DragIndicator } from '@styled-icons/material/DragIndicator';
 import {
   AlignPlugin,
   BalloonToolbar,
@@ -150,6 +151,15 @@ const draggableComponentOptions = [
       component: getSelectableElement({
         component,
         level,
+        dragIcon: (
+          <DragIndicator
+            style={{
+              width: 18,
+              height: 18,
+              color: 'rgba(55, 53, 47, 0.3)',
+            }}
+          />
+        ),
         styles: {
           blockAndGutter: {
             padding: '4px 0',


### PR DESCRIPTION
## Issue
Importing  @styled-icons from within packages source results in styled-components being included in slate-plugins bundle.

## What I did
- Added `no-restricted-imports` rule to ensure @styled-icons won't be imported from within /packages source files,
- Removed `@styled-icons/material/DragIndicator` from Selectable component,
- Added optional dragIcon argument to getSelectableElement, 
- Updated drag and drop story to include DragIndicator icon previously used in Selectable component, so the story looks the same way it did before the change

Note: there is no default icon provided, also the dragIcon attribute is optional

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.

## References
[Initial pull request](https://github.com/udecode/slate-plugins/pull/356).


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->