### PR TITLE
Lazy - create enriched blockquote

### DIFF
--- a/packages/slate-plugins/src/elements/blockquote/defaults.ts
+++ b/packages/slate-plugins/src/elements/blockquote/defaults.ts
@@ -1,3 +1,5 @@
+import { StyledElement } from '../../components/StyledComponent';
+import { ELEMENT_PARAGRAPH } from '../paragraph';
 import { BlockquoteElement } from './components/BlockquoteElement';
 import { BlockquoteKeyOption, BlockquotePluginOptionsValues } from './types';
 
@@ -14,6 +16,20 @@ export const DEFAULTS_BLOCKQUOTE: Record<
     rootProps: {
       className: 'slate-blockquote',
       as: 'blockquote',
+    },
+  },
+  p: {
+    component: StyledElement,
+    type: ELEMENT_PARAGRAPH,
+    rootProps: {
+      className: `slate-${ELEMENT_BLOCKQUOTE}-${ELEMENT_PARAGRAPH}`,
+      as: 'div',
+      styles: {
+        root: {
+          // Get rid of default style
+          margin: '0',
+        },
+      },
     },
   },
 };

--- a/packages/slate-plugins/src/elements/blockquote/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/index.ts
@@ -1,4 +1,5 @@
 export * from './components';
+export * from './transforms';
 export * from './BlockquotePlugin';
 export * from './defaults';
 export * from './deserializeBlockquote';

--- a/packages/slate-plugins/src/elements/blockquote/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/index.ts
@@ -5,3 +5,4 @@ export * from './defaults';
 export * from './deserializeBlockquote';
 export * from './renderElementBlockquote';
 export * from './types';
+export * from './withBlockquote';

--- a/packages/slate-plugins/src/elements/blockquote/transforms/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/index.ts
@@ -1,0 +1,1 @@
+export * from './toggleBlockquote';

--- a/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
@@ -1,0 +1,31 @@
+import { Editor } from 'slate';
+import { isNodeTypeIn } from '../../../common/queries';
+import { wrapNodes } from '../../../common/transforms/wrapNodes';
+import { ListOptions } from '../../list/types';
+import { ELEMENT_PARAGRAPH } from '../../paragraph/defaults';
+
+export const toggleBlockquote = (
+  editor: Editor,
+  {
+    typeList,
+  }: {
+    typeList: string;
+  } & ListOptions
+) => {
+  if (!editor.selection) return;
+
+  const isActive = isNodeTypeIn(editor, typeList);
+
+  if (!isActive) {
+    const list = {
+      type: typeList,
+      children: [
+        {
+          type: ELEMENT_PARAGRAPH,
+          children: [{ text: '' }],
+        },
+      ],
+    };
+    wrapNodes(editor, list);
+  }
+};

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -39,7 +39,7 @@ export interface BlockquoteElementProps
   element: BlockquoteNode;
 }
 
-export type BlockquoteKeyOption = 'blockquote';
+export type BlockquoteKeyOption = 'blockquote' | 'p';
 
 // Plugin options
 export type BlockquotePluginOptionsValues = RenderNodeOptions &
@@ -79,3 +79,5 @@ export interface BlockquoteElementStyleProps {
 
   // Insert BlockquoteElement style props below
 }
+
+export interface BlockQuoteOptions extends BlockquotePluginOptions<'type'> {}

--- a/packages/slate-plugins/src/elements/blockquote/withBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/withBlockquote.ts
@@ -1,0 +1,42 @@
+import { Transforms } from 'slate';
+import { ReactEditor } from 'slate-react';
+import { BlockQuoteOptions, getParent } from '../..';
+import { setDefaults } from '../../common/utils/setDefaults';
+import { DEFAULTS_BLOCKQUOTE, ELEMENT_BLOCKQUOTE } from './defaults';
+
+export const withBlockquote = (options?: BlockQuoteOptions) => <
+  T extends ReactEditor
+>(
+  editor: T
+) => {
+  const { p } = setDefaults(options, DEFAULTS_BLOCKQUOTE);
+  const { insertText } = editor;
+
+  editor.insertText = (node) => {
+    if (!editor.selection) return;
+
+    // Get the parent of our current selection
+    const selectionParentEntry = getParent(editor, editor.selection);
+    if (!selectionParentEntry) return;
+
+    const [elem, elemPath] = selectionParentEntry;
+
+    // If the direct parent is a node of ELEMENT_BLOCKQUOTE type
+    if (elem?.type === ELEMENT_BLOCKQUOTE) {
+      const blockedQuoteChildren = {
+        type: p.type,
+        children: [{ text: node }],
+      };
+
+      // Let's add a new <p> node
+      // at the current <blockquote>
+      // to enriched it
+      return Transforms.insertNodes(editor, blockedQuoteChildren, {
+        at: [...elemPath, 0],
+      });
+    }
+
+    insertText(node);
+  };
+  return editor;
+};

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -70,14 +70,6 @@ export const autoformatRules: AutoformatRule[] = [
     preFormat,
   },
   {
-    type: options.blockquote.type,
-    markup: ['>*'],
-    preFormat,
-    format: (editor) => {
-      toggleBlockquote(editor, { ...options, typeList: options.blockquote.type });
-    },
-  },
-  {
     type: MARK_BOLD,
     between: ['**', '**'],
     mode: 'inline',

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -4,6 +4,7 @@ import {
   MARK_CODE,
   MARK_ITALIC,
   MARK_STRIKETHROUGH,
+  toggleBlockquote,
   toggleList,
   unwrapList,
 } from '@udecode/slate-plugins';
@@ -67,6 +68,14 @@ export const autoformatRules: AutoformatRule[] = [
     type: options.blockquote.type,
     markup: ['>'],
     preFormat,
+  },
+  {
+    type: options.blockquote.type,
+    markup: ['>*'],
+    preFormat,
+    format: (editor) => {
+      toggleBlockquote(editor, { ...options, typeList: options.blockquote.type });
+    },
   },
   {
     type: MARK_BOLD,

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -1049,6 +1049,16 @@ export const initialValueSoftBreak: SlateDocument = [
     ] as SlateDocumentFragment,
   },
 ];
+export const initialValueBlockquote: SlateDocument = [
+  {
+    children: [
+      {
+        type: options.blockquote.type,
+        children: [{ text: 'Try here ⏎' }],
+      },     
+    ] as SlateDocumentFragment,
+  },
+];
 
 export const initialValueExitBreak: SlateDocument = [
   {

--- a/stories/elements/blockquote.lazy.stories.tsx
+++ b/stories/elements/blockquote.lazy.stories.tsx
@@ -21,6 +21,7 @@ import {
   ToolbarElement,
   ToolbarList,
   withAutoformat,
+  withBlockquote,
   withList,
   withMarks,
 } from '@udecode/slate-plugins';
@@ -49,12 +50,12 @@ const withPlugins = [
   withReact,
   withHistory,
   withList(options),
+  withBlockquote(options),
   withMarks(),
   withAutoformat({ rules: autoformatRules }),
   ] as const;
 
 const initialValue: Node[] = [  
-  ...initialValueBlockquote, 
   ...initialValueList, 
 ];
 

--- a/stories/elements/blockquote.lazy.stories.tsx
+++ b/stories/elements/blockquote.lazy.stories.tsx
@@ -1,0 +1,151 @@
+import 'prismjs/themes/prism.css';
+import React, { useMemo, useState } from 'react';
+import { boolean } from '@storybook/addon-knobs';
+import {
+  FormatQuote, 
+} from '@styled-icons/material';
+import {
+  BlockquotePlugin,
+  BoldPlugin,
+  EditablePlugins,
+  ExitBreakPlugin,
+  HeadingToolbar,
+  ItalicPlugin,
+  ListPlugin,
+  ParagraphPlugin,
+  pipe,
+  ResetBlockTypePlugin,
+  SlatePlugin,
+  SoftBreakPlugin,
+  TodoListPlugin,
+  ToolbarElement,
+  ToolbarList,
+  withAutoformat,
+  withList,
+  withMarks,
+} from '@udecode/slate-plugins';
+import { createEditor ,Node} from 'slate';
+import { withHistory } from 'slate-history';
+import { Slate, withReact } from 'slate-react';
+import {
+  headingTypes,
+  initialValueList,
+  initialValueBlockquote,
+  options,
+  optionsResetBlockTypes,
+} from '../config/initialValues';
+import { autoformatRules } from '../config/autoformatRules';
+import { FormatListBulleted, FormatListNumbered } from 'styled-icons/material';
+
+export default {
+  title: 'Elements/Lazy - BlockquotePlugin enriched',
+  subcomponents: {
+    BlockquotePlugin,
+    ParagraphPlugin,
+  },
+};
+
+const withPlugins = [
+  withReact,
+  withHistory,
+  withList(options),
+  withMarks(),
+  withAutoformat({ rules: autoformatRules }),
+  ] as const;
+
+const initialValue: Node[] = [  
+  ...initialValueBlockquote, 
+  ...initialValueList, 
+];
+
+export const Example = () => {
+  const plugins: SlatePlugin[] = [];
+  if (boolean('ParagraphPlugin', true)) plugins.push(ParagraphPlugin(options));
+  if (boolean('BlockquotePlugin', true))
+    plugins.push(BlockquotePlugin(options));  
+  if (boolean('ListPlugin', true)) plugins.push(ListPlugin(options));
+  if (boolean('BoldPlugin', true)) plugins.push(BoldPlugin(options));
+  if (boolean('ItalicPlugin', true)) plugins.push(ItalicPlugin(options));
+  if (boolean('TodoListPlugin', true)) plugins.push(TodoListPlugin(options));
+  if (boolean('ResetBlockTypePlugin', true))
+    plugins.push(ResetBlockTypePlugin(optionsResetBlockTypes));
+  if (boolean('SoftBreakPlugin', true))
+    plugins.push(
+      SoftBreakPlugin({
+        rules: [
+          { hotkey: 'shift+enter' },
+          {
+            hotkey: 'enter',
+            query: {
+              allow: [options.code_block.type, options.blockquote.type],
+            },
+          },
+        ],
+      })
+    );
+  if (boolean('ExitBreakPlugin', true))
+    plugins.push(
+      ExitBreakPlugin({
+        rules: [
+          {
+            hotkey: 'mod+enter',
+          },
+          {
+            hotkey: 'mod+shift+enter',
+            before: true,
+          },
+          {
+            hotkey: 'enter',
+            query: {
+              start: true,
+              end: true,
+              allow: headingTypes,
+            },
+          },
+        ],
+      })
+    );
+
+  const createReactEditor = () => () => {
+    const [value, setValue] = useState(initialValue);
+
+    const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
+
+    return (
+      <Slate
+        editor={editor}
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+      >
+        <HeadingToolbar>
+          <ToolbarElement
+            type={options.blockquote.type}
+            icon={<FormatQuote />}
+          />
+          <ToolbarList
+            {...options}
+            typeList={options.ul.type}
+            icon={<FormatListBulleted />}
+          />
+          <ToolbarList
+            {...options}
+            typeList={options.ol.type}
+            icon={<FormatListNumbered />}
+          />
+        </HeadingToolbar>
+        <EditablePlugins
+          plugins={plugins}
+          placeholder="Enter some rich text…"
+          spellCheck
+          autoFocus
+        />
+      </Slate>
+    );
+  };
+
+  const Editor = createReactEditor();
+
+  return <Editor />;
+};


### PR DESCRIPTION
Enriched blockquote component.
![image](https://user-images.githubusercontent.com/2158425/100379063-960f5b00-3014-11eb-8296-12e942c30e60.png)

I've been inspired by these two files:
- https://github.com/wdelmas/slate-plugins/blob/lazy-blockquote-enrich/packages/slate-plugins/src/elements/list/transforms/toggleList.ts
- https://github.com/wdelmas/slate-plugins/blob/lazy-blockquote-enrich/packages/slate-plugins/src/elements/table/utils/getEmptyCellNode.ts

I've created a  story to test the behavior.
I've spent around 4 hours on it.
