### PR TITLE
consistent pass list options to getListItemSubList to support AST types

### DIFF
--- a/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.spec.tsx
+++ b/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.spec.tsx
@@ -44,7 +44,7 @@ describe('deleteListFragment', () => {
         </editor>
       ) as any) as Editor;
 
-      const actual = deleteListFragment(editor, editor.selection as Range);
+      const actual = deleteListFragment(editor, editor.selection as Range, {});
 
       expect(actual).toBeUndefined();
     });
@@ -89,7 +89,7 @@ describe('deleteListFragment', () => {
         </editor>
       ) as any) as Editor;
 
-      const actual = deleteListFragment(editor, editor.selection as any);
+      const actual = deleteListFragment(editor, editor.selection as any, {});
 
       expect(actual).toBeUndefined();
     });
@@ -138,7 +138,7 @@ describe('deleteListFragment', () => {
 
       const editor = withHistory(input);
 
-      const actual = deleteListFragment(editor, editor.selection);
+      const actual = deleteListFragment(editor, editor.selection, {});
 
       expect(actual).toEqual(3);
       const expected = [
@@ -217,7 +217,7 @@ describe('deleteListFragment', () => {
 
       const editor = withHistory(input);
 
-      const actual = deleteListFragment(editor, editor.selection as any);
+      const actual = deleteListFragment(editor, editor.selection as any, {});
 
       expect(actual).toEqual(3);
       const expected = [
@@ -296,7 +296,7 @@ describe('deleteListFragment', () => {
 
       const editor = withHistory(input);
 
-      const actual = deleteListFragment(editor, editor.selection as any);
+      const actual = deleteListFragment(editor, editor.selection as any, {});
 
       expect(actual).toEqual(0);
       const expected = [
@@ -377,7 +377,7 @@ describe('deleteListFragment', () => {
 
       const editor = withHistory(input);
 
-      const actual = deleteListFragment(editor, editor.selection as any);
+      const actual = deleteListFragment(editor, editor.selection as any, {});
 
       expect(actual).toEqual(2);
       const expected = [

--- a/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
@@ -59,7 +59,7 @@ export const deleteListFragment = (
       childrenMoved = moveListItemSublistItemsToList(editor, {
         fromListItem: listItemEnd,
         toList: [toListNode as Ancestor, next],
-      });
+      }, options);
 
       // next is the first list item of the root copy.
       next = [...next, 0];

--- a/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
@@ -80,7 +80,7 @@ export const deleteListFragment = (
       childrenMoved = moveListItemSublistItemsToListItemSublist(editor, {
         fromListItem: listItemEnd,
         toListItem: listItemStart,
-      });
+      }, options);
 
       next = listItemSublist
         ? Path.next(getLastChildPath(listItemSublist))

--- a/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.spec.tsx
+++ b/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.spec.tsx
@@ -56,7 +56,7 @@ it('should', () => {
   const toList = getNodeById(editor, '1') as NodeEntry<Ancestor>;
 
   if (fromListItem && toList) {
-    moveListItemSublistItemsToList(editor, { fromListItem, toList });
+    moveListItemSublistItemsToList(editor, { fromListItem, toList }, {});
   }
 
   expect(input.children).toEqual(output.children);

--- a/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.ts
@@ -27,7 +27,7 @@ export interface MergeListItemIntoListOptions {
 export const moveListItemSublistItemsToList = (
   editor: Editor,
   { fromListItem, toList, start }: MergeListItemIntoListOptions,
-  options: ListOptions
+  options: ListOptions = {}
 ) => {
   const fromListItemSublist = getListItemSublist(fromListItem, options);
   if (!fromListItemSublist) return 0;

--- a/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.ts
@@ -27,7 +27,7 @@ export interface MergeListItemIntoListOptions {
 export const moveListItemSublistItemsToList = (
   editor: Editor,
   { fromListItem, toList, start }: MergeListItemIntoListOptions,
-  options: ListOptions = {}
+  options?: ListOptions
 ) => {
   const fromListItemSublist = getListItemSublist(fromListItem, options);
   if (!fromListItemSublist) return 0;

--- a/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToList.ts
@@ -2,6 +2,7 @@ import { Ancestor, Editor, NodeEntry, Path, Transforms } from 'slate';
 import { getLastChildPath } from '../../../common/queries/getLastChild';
 import { moveChildren } from '../../../common/transforms/moveChildren';
 import { getListItemSublist } from '../queries/getListItemSublist';
+import { ListOptions } from '../types';
 
 export interface MergeListItemIntoListOptions {
   /**
@@ -25,9 +26,10 @@ export interface MergeListItemIntoListOptions {
  */
 export const moveListItemSublistItemsToList = (
   editor: Editor,
-  { fromListItem, toList, start }: MergeListItemIntoListOptions
+  { fromListItem, toList, start }: MergeListItemIntoListOptions,
+  options: ListOptions
 ) => {
-  const fromListItemSublist = getListItemSublist(fromListItem);
+  const fromListItemSublist = getListItemSublist(fromListItem, options);
   if (!fromListItemSublist) return 0;
 
   const [, fromListItemSublistPath] = fromListItemSublist;

--- a/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToListItemSublist.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToListItemSublist.ts
@@ -3,6 +3,7 @@ import { getLastChildPath } from '../../../common/queries/getLastChild';
 import { getParent } from '../../../common/queries/getParent';
 import { moveChildren } from '../../../common/transforms/moveChildren';
 import { getListItemSublist } from '../queries/getListItemSublist';
+import { ListOptions } from '../types';
 
 export interface MoveListItemSublistItemsToListItemSublistOptions {
   /**
@@ -31,16 +32,17 @@ export const moveListItemSublistItemsToListItemSublist = (
     fromListItem,
     toListItem,
     start,
-  }: MoveListItemSublistItemsToListItemSublistOptions
+  }: MoveListItemSublistItemsToListItemSublistOptions,
+  options?: ListOptions
 ) => {
   const [, fromListItemPath] = fromListItem;
   const [, toListItemPath] = toListItem;
 
-  const fromListItemSublist = getListItemSublist(fromListItem);
+  const fromListItemSublist = getListItemSublist(fromListItem, options);
   if (!fromListItemSublist) return 0;
   const [, fromListItemSublistPath] = fromListItemSublist;
 
-  const toListItemSublist = getListItemSublist(toListItem);
+  const toListItemSublist = getListItemSublist(toListItem, options);
 
   let to: Path;
 


### PR DESCRIPTION
## Issue

The fixes for #65 did not address the scenario where a non-standard type gets used in the editor (e.g. something besides ul/ol for lists).

## What I did

Made certain that ListOptions gets passed to getListItemSubList if specified to override the default.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.