### PR TITLE
verify list options passed via removeRootListItem codepath

### DIFF
--- a/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToListItemSublist.spec.tsx
+++ b/packages/slate-plugins/src/elements/list/transforms/moveListItemSublistItemsToListItemSublist.spec.tsx
@@ -69,10 +69,14 @@ describe('when there is toListItem sublist', () => {
     const toListItem = getNodeById(editor, '11') as NodeEntry<Ancestor>;
 
     if (fromListItem && toListItem) {
-      moveListItemSublistItemsToListItemSublist(editor, {
-        fromListItem,
-        toListItem,
-      });
+      moveListItemSublistItemsToListItemSublist(
+        editor,
+        {
+          fromListItem,
+          toListItem,
+        },
+        {}
+      );
     }
 
     expect(input.children).toEqual(output.children);
@@ -129,10 +133,14 @@ describe('when there is no list in toListItem', () => {
     const toListItem = getNodeById(editor, '11') as NodeEntry<Ancestor>;
 
     if (fromListItem && toListItem) {
-      moveListItemSublistItemsToListItemSublist(editor, {
-        fromListItem,
-        toListItem,
-      });
+      moveListItemSublistItemsToListItemSublist(
+        editor,
+        {
+          fromListItem,
+          toListItem,
+        },
+        {}
+      );
     }
 
     expect(input.children).toEqual(output.children);

--- a/packages/slate-plugins/src/elements/list/transforms/removeRootListItem.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/removeRootListItem.ts
@@ -44,7 +44,7 @@ export const removeRootListItem = (
       moveListItemSublistItemsToListItemSublist(editor, {
         fromListItem: listItem,
         toListItem: [previousListItemNode as Ancestor, previousListItemPath],
-      });
+      }, options);
 
       // Select the P tag at the previous list item
       Transforms.select(
@@ -58,7 +58,7 @@ export const removeRootListItem = (
         fromListItem: listItem,
         toList: list,
         // start: true,
-      });
+      }, options);
     }
 
     // Remove the list-item


### PR DESCRIPTION
## Issue

One more possible complication related to #65

## What I did

Make sure list options get passed via the removeRootListItem code path also.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.