### PR TITLE
allow list items to have ol as children

### DIFF
--- a/packages/slate-plugins/src/elements/list/normalizers/normalizeListItem.ts
+++ b/packages/slate-plugins/src/elements/list/normalizers/normalizeListItem.ts
@@ -17,9 +17,9 @@ export const normalizeListItem = (
   }: { nodeEntry: NodeEntry } & ListNormalizerOptions,
   options?: ListOptions
 ) => {
-  const { p, ul } = setDefaults(options, DEFAULTS_LIST);
+  const { p, ul, ol } = setDefaults(options, DEFAULTS_LIST);
 
-  const allValidLiChildrenTypes = [ul.type, p.type, ...validLiChildrenTypes];
+  const allValidLiChildrenTypes = [ul.type, ol.type, p.type, ...validLiChildrenTypes];
 
   const [listItemNode, listItemPath] = nodeEntry;
   const firstChildPath: Path = listItemPath.concat([0]);


### PR DESCRIPTION
## Issue

In an ordered list, pressing tab to indent a child was pushing the ordered list item to the wrong place in the tree.

A bit more severe, changing a nested list item from unordered to ordered with a custom ast grammar was causing an infinite insertion of p elements until giving up. Related, I have no idea why this normalization was ignoring the ast options getting passed in, but there may be somewhere in the codebase where a normalization rule is ignoring or not getting passed options, but I don't see it.

## What I did

Allow ol as a valid child type of li (in addition to p and ul). While it could be argued that the user should need to specify ol as a valid child type, the behavior for this bug was particularly challenging to track down, and it was also result

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.