### PR TITLE
Add missing code_block type to parseMD

### DIFF
--- a/packages/slate-plugins/src/deserializers/deserialize-md/utils/parseMD.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-md/utils/parseMD.ts
@@ -3,6 +3,7 @@ import slate from 'remark-slate';
 import unified from 'unified';
 import { setDefaults } from '../../../common/utils/setDefaults';
 import { ELEMENT_BLOCKQUOTE } from '../../../elements/blockquote/defaults';
+import { ELEMENT_CODE_BLOCK } from '../../../elements/code-block/defaults';
 import {
   ELEMENT_H1,
   ELEMENT_H2,
@@ -12,7 +13,6 @@ import {
   ELEMENT_H6,
 } from '../../../elements/heading/defaults';
 import { ELEMENT_LINK } from '../../../elements/link/defaults';
-import { ELEMENT_CODE_BLOCK } from '../../../elements/code-block/defaults';
 import {
   ELEMENT_LI,
   ELEMENT_OL,
@@ -39,7 +39,7 @@ export const parseMD = (options?: Record<string, any>) => (content: string) => {
     p: { type: ELEMENT_PARAGRAPH },
     blockquote: { type: ELEMENT_BLOCKQUOTE },
     link: { type: ELEMENT_LINK },
-    code: { type: ELEMENT_CODE_BLOCK},
+    code: { type: ELEMENT_CODE_BLOCK },
     ul: { type: ELEMENT_UL },
     ol: { type: ELEMENT_OL },
     li: { type: ELEMENT_LI },

--- a/packages/slate-plugins/src/deserializers/deserialize-md/utils/parseMD.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-md/utils/parseMD.ts
@@ -12,6 +12,7 @@ import {
   ELEMENT_H6,
 } from '../../../elements/heading/defaults';
 import { ELEMENT_LINK } from '../../../elements/link/defaults';
+import { ELEMENT_CODE_BLOCK } from '../../../elements/code-block/defaults';
 import {
   ELEMENT_LI,
   ELEMENT_OL,
@@ -24,6 +25,7 @@ export const parseMD = (options?: Record<string, any>) => (content: string) => {
     p,
     blockquote,
     link,
+    code,
     ul,
     ol,
     li,
@@ -37,6 +39,7 @@ export const parseMD = (options?: Record<string, any>) => (content: string) => {
     p: { type: ELEMENT_PARAGRAPH },
     blockquote: { type: ELEMENT_BLOCKQUOTE },
     link: { type: ELEMENT_LINK },
+    code: { type: ELEMENT_CODE_BLOCK},
     ul: { type: ELEMENT_UL },
     ol: { type: ELEMENT_OL },
     li: { type: ELEMENT_LI },
@@ -55,6 +58,7 @@ export const parseMD = (options?: Record<string, any>) => (content: string) => {
         paragraph: p.type,
         block_quote: blockquote.type,
         link: link.type,
+        code_block: code.type,
         ul_list: ul.type,
         ol_list: ol.type,
         listItem: li.type,


### PR DESCRIPTION
## Issue

parseMD is missing the code_block type from the options passed to remark-slate/unified

## What I did

Added the missing type and a default value

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.