### PR TITLE
respect ast type options for child p in getEmptyCellNode

### DIFF
--- a/packages/slate-plugins/src/elements/table/utils/getEmptyCellNode.ts
+++ b/packages/slate-plugins/src/elements/table/utils/getEmptyCellNode.ts
@@ -1,18 +1,22 @@
 import { setDefaults } from '../../../common/utils/setDefaults';
-import { ELEMENT_PARAGRAPH } from '../../paragraph';
+import { DEFAULTS_PARAGRAPH } from '../../paragraph';
+import { ParagraphPluginOptions } from '../../paragraph/types';
 import { DEFAULTS_TABLE } from '../defaults';
 import { TableOptions } from '../types';
 
 export const getEmptyCellNode = (
-  options?: TableOptions & { header?: boolean }
+  options?: TableOptions & ParagraphPluginOptions & { header?: boolean }
 ) => {
-  const { th, td, header } = setDefaults(options, DEFAULTS_TABLE);
+  const { th, td, header, p } = setDefaults(options, {
+    ...DEFAULTS_TABLE,
+    ...DEFAULTS_PARAGRAPH,
+  });
 
   return {
     type: header ? th.type : td.type,
     children: [
       {
-        type: ELEMENT_PARAGRAPH,
+        type: p.type,
         children: [{ text: '' }],
       },
     ],


### PR DESCRIPTION
## Issue

Partial fix towards respecting table normalization rules

## What I did

getEmptyCellNode now accepts and sets option for p.type

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.