### PR TITLE
deserialization rule to match on either an attribute name or value

### DIFF
--- a/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
@@ -22,6 +22,11 @@ export interface GetNodeDeserializerRule {
   style?: Partial<
     Record<keyof CSSStyleDeclaration, string | string[] | undefined>
   >;
+
+  /**
+   * Required attribute name or name + value
+   */
+  attribute?: string | { [key: string]: string | string[] };
 }
 
 export interface GetNodeDeserializerOptions {
@@ -54,7 +59,7 @@ export const getNodeDeserializer = ({
 }: GetNodeDeserializerOptions) => {
   const deserializers: DeserializeNode[] = [];
 
-  rules.forEach(({ nodeNames = '*', style, className }) => {
+  rules.forEach(({ nodeNames = '*', style, className, attribute }) => {
     nodeNames = castArray<string>(nodeNames);
 
     nodeNames.forEach((nodeName) => {
@@ -78,12 +83,25 @@ export const getNodeDeserializer = ({
             }
           }
 
+          if (attribute) {
+            if (typeof attribute === 'string') {
+              if (!el.getAttributeNames().includes(attribute)) return;
+            } else {
+              for (const [key, value] of Object.entries(attribute)) {
+                const values = castArray<string>(value);
+                const attr = el.getAttribute(key);
+
+                if (!attr || !values.includes(attr)) return;
+              }
+            }
+          }
+
           const htmlAttributes = {};
           if (attributes) {
             const attributeNames = el.getAttributeNames();
-            for (const attribute of attributes) {
-              if (attributeNames.includes(attribute))
-                htmlAttributes[attribute] = el.getAttribute(attribute);
+            for (const attr of attributes) {
+              if (attributeNames.includes(attr))
+                htmlAttributes[attr] = el.getAttribute(attr);
             }
           }
 

--- a/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/match-on-attribute.spec.tsx
+++ b/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/match-on-attribute.spec.tsx
@@ -1,0 +1,62 @@
+/** @jsx jsx */
+
+import { getHtmlDocument } from '../../../../__test-utils__/getHtmlDocument';
+import { jsx } from '../../../../__test-utils__/jsx';
+import { getElementDeserializer } from '../../../../common/utils';
+import { deserializeHTMLElement } from '../../../index';
+
+const html1 = '<html><body><div data-poll-id="456"/></body></html>';
+const element1 = getHtmlDocument(html1).body;
+const input1 = {
+  plugins: [
+    {
+      deserialize: {
+        element: getElementDeserializer({
+          type: 'poll',
+          node: (el) => ({
+            type: 'poll',
+            id: el.getAttribute('data-poll-id'),
+          }),
+          rules: [{ attribute: 'data-poll-id' }],
+        }),
+      },
+    },
+  ],
+  element: element1,
+};
+
+const output = (
+  <editor>
+    <block type="poll" id="456">
+      <htext />
+    </block>
+  </editor>
+) as any;
+
+it('should match with the attribute name', () => {
+  expect(deserializeHTMLElement(input1)).toEqual(output.children);
+});
+
+const html2 = '<html><body><div data-type="poll" data-id="456"/></body></html>';
+const element2 = getHtmlDocument(html2).body;
+const input2 = {
+  plugins: [
+    {
+      deserialize: {
+        element: getElementDeserializer({
+          type: 'poll',
+          node: (el) => ({
+            type: 'poll',
+            id: el.getAttribute('data-id'),
+          }),
+          rules: [{ attribute: { 'data-type': 'poll' } }],
+        }),
+      },
+    },
+  ],
+  element: element2,
+};
+
+it('should match with the attribute name and value', () => {
+  expect(deserializeHTMLElement(input2)).toEqual(output.children);
+});

--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-serialize.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/with-serialize.spec.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { RenderElementProps, RenderLeafProps } from 'slate-react';
 import {
   BoldPlugin,
   htmlStringToDOMNode,
@@ -15,7 +16,7 @@ it('custom serialize image to html', () => {
           {
             ...ImagePlugin(),
             serialize: {
-              element: ({ element }) =>
+              element: ({ element }: RenderElementProps) =>
                 React.createElement('img', { src: element.url }),
             },
           },
@@ -42,7 +43,7 @@ it('custom serialize bold to html', () => {
         {
           ...BoldPlugin(),
           serialize: {
-            leaf: ({ leaf, children }) =>
+            leaf: ({ leaf, children }: RenderLeafProps) =>
               leaf[MARK_BOLD] && !!leaf.text
                 ? React.createElement('b', {}, children)
                 : children,


### PR DESCRIPTION
## Issue

While deserializing html from a 3rd party source, there's a few cases where the only distinguishing aspect of a DOM node is a unique attribute name.  To be able to deserialize this into a custom plugin, it would be great to make a deserialization rule that would match either an attribute name or an attribute name + value.

## What I did

Expanded `GetNodeDeserializerRule` to take an optional attribute property that would subsequently match either if the attribute name (if given a string) is found or if the attribute name and one of its values is found (if given an object).

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->