### PR TITLE
node deserializer can instruct not to include children on its element

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,7 @@ export type DeserializeNode = {
         [key: string]: unknown;
       }
     | undefined;
+  withoutChildren?: boolean;
 };
 
 export interface DeserializeHtml {

--- a/packages/slate-plugins/src/common/utils/getLeafDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getLeafDeserializer.ts
@@ -5,7 +5,10 @@ import {
 } from './getNodeDeserializer';
 
 export interface GetLeafDeserializerOptions
-  extends WithOptional<GetNodeDeserializerOptions, 'node'> {
+  extends WithOptional<
+    Omit<GetNodeDeserializerOptions, 'withoutChildren'>,
+    'node'
+  > {
   type: string;
 }
 

--- a/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
+++ b/packages/slate-plugins/src/common/utils/getNodeDeserializer.ts
@@ -46,6 +46,11 @@ export interface GetNodeDeserializerOptions {
    * List of rules the element needs to follow to be deserialized to a slate node.
    */
   rules: GetNodeDeserializerRule[];
+
+  /**
+   * Whether or not to include deserialized children on this node
+   */
+  withoutChildren?: boolean;
 }
 
 /**
@@ -56,6 +61,7 @@ export const getNodeDeserializer = ({
   node,
   attributes,
   rules,
+  withoutChildren,
 }: GetNodeDeserializerOptions) => {
   const deserializers: DeserializeNode[] = [];
 
@@ -65,6 +71,7 @@ export const getNodeDeserializer = ({
     nodeNames.forEach((nodeName) => {
       deserializers.push({
         type,
+        withoutChildren,
         deserialize: (el) => {
           if (
             nodeNames.length &&

--- a/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/element-without-children.spec.tsx
+++ b/packages/slate-plugins/src/deserializers/deserialize-html/__tests__/deserializeHTMLElement/element-without-children.spec.tsx
@@ -1,0 +1,41 @@
+/** @jsx jsx */
+
+import { getHtmlDocument } from '../../../../__test-utils__/getHtmlDocument';
+import { jsx } from '../../../../__test-utils__/jsx';
+import { getElementDeserializer } from '../../../../common/utils';
+import { deserializeHTMLElement } from '../../../index';
+
+const html =
+  '<html><body><div class="poll" data-id="456"><ul><li>Question 1</li><li>Question 2</li></ul></div></body></html>';
+const element = getHtmlDocument(html).body;
+
+const input = {
+  plugins: [
+    {
+      deserialize: {
+        element: getElementDeserializer({
+          type: 'poll',
+          node: (el) => ({
+            type: 'poll',
+            id: el.getAttribute('data-id'),
+          }),
+          rules: [{ className: 'poll' }],
+          withoutChildren: true,
+        }),
+      },
+    },
+  ],
+  element,
+};
+
+const output = (
+  <editor>
+    <block type="poll" id="456">
+      <htext />
+    </block>
+  </editor>
+) as any;
+
+it('should include named attributes', () => {
+  expect(deserializeHTMLElement(input)).toEqual(output.children);
+});

--- a/packages/slate-plugins/src/deserializers/deserialize-html/utils/deserializeHTMLToElement.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-html/utils/deserializeHTMLToElement.ts
@@ -16,6 +16,7 @@ export const deserializeHTMLToElement = ({
   children: DeserializeHTMLChildren[];
 }): Element | undefined => {
   let slateElement: any;
+  let withoutChildren: boolean | undefined;
 
   plugins.some(({ deserialize: pluginDeserializers }) => {
     if (!pluginDeserializers?.element) return;
@@ -25,13 +26,14 @@ export const deserializeHTMLToElement = ({
       if (!deserialized) return;
 
       slateElement = deserialized;
+      withoutChildren = deserializer.withoutChildren;
       return true;
     });
   });
 
   if (slateElement) {
     let descendants = children as Descendant[];
-    if (!descendants.length) {
+    if (!descendants.length || withoutChildren) {
       descendants = [{ text: '' }];
     }
 


### PR DESCRIPTION
## Issue

While deserializing, an element may include children elements that are not meaningful in the slate document or may be problematic.  It would be handy to create a single element that could encapsulate information about its children (or ignore them) without them being explicitly represented in the slate document.  This would be helpful to control how a deserialized element is rendered in the slate document or serialized back out.

## What I did

New `withoutChildren` optional property on `GetNodeDeserializerOptions` that, when true, will not add any children to the deserialized element.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->