### PR TITLE
add getImageUrl prop to ToolbarImage

### DIFF
--- a/packages/slate-plugins/src/elements/image/__tests__/ToolbarImage/onMouseDown.spec.tsx
+++ b/packages/slate-plugins/src/elements/image/__tests__/ToolbarImage/onMouseDown.spec.tsx
@@ -22,3 +22,27 @@ it('should render', () => {
 
   expect(editor.children).toEqual(output.children);
 });
+
+it('should invoke getUrlImage when provided', () => {
+  const editor = input;
+
+  jest.spyOn(SlateReact, 'useEditor').mockReturnValue(editor as any);
+  jest
+    .spyOn(window, 'prompt')
+    .mockReturnValue('https://i.imgur.com/removed.png');
+
+  const getImageUrlMock = jest.fn();
+
+  const { getByTestId } = render(
+    <ToolbarImage
+      type={ELEMENT_H1}
+      img={{ rootProps: { getImageUrl: getImageUrlMock } }}
+      icon={null}
+    />
+  );
+
+  const element = getByTestId('ToolbarButton');
+  fireEvent.mouseDown(element);
+
+  expect(getImageUrlMock).toBeCalledTimes(1);
+});

--- a/packages/slate-plugins/src/elements/image/components/ToolbarImage.tsx
+++ b/packages/slate-plugins/src/elements/image/components/ToolbarImage.tsx
@@ -10,15 +10,21 @@ import { ImagePluginOptions } from '../types';
 export const ToolbarImage = ({
   img,
   ...props
-}: ToolbarButtonProps & ImagePluginOptions<'type'>) => {
+}: ToolbarButtonProps &
+  ImagePluginOptions<'type'> &
+  ImagePluginOptions<'rootProps'>) => {
   const editor = useEditor();
 
   return (
     <ToolbarButton
-      onMouseDown={(event) => {
+      onMouseDown={async (event) => {
         event.preventDefault();
-
-        const url = window.prompt('Enter the URL of the image:');
+        let url = undefined;
+        if (img?.rootProps?.getImageUrl != null) {
+          url = await img.rootProps.getImageUrl();
+        } else {
+          url = window.prompt('Enter the URL of the image:');
+        }
         if (!url) return;
         insertImage(editor, url, { img });
       }}

--- a/packages/slate-plugins/src/elements/image/components/ToolbarImage.tsx
+++ b/packages/slate-plugins/src/elements/image/components/ToolbarImage.tsx
@@ -19,7 +19,7 @@ export const ToolbarImage = ({
     <ToolbarButton
       onMouseDown={async (event) => {
         event.preventDefault();
-        let url = undefined;
+        let url;
         if (img?.rootProps?.getImageUrl != null) {
           url = await img.rootProps.getImageUrl();
         } else {

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -24,6 +24,10 @@ export interface ImageRenderElementPropsOptions {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<ImageElementStyleProps, ImageElementStyles>;
+  /**
+   * The provided function is invoked by clicking on the the ToolbarImage, and the
+   * resulting url is inserted as an image to the document.
+   */
   getImageUrl?: () => Promise<string>;
 }
 

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -24,6 +24,7 @@ export interface ImageRenderElementPropsOptions {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<ImageElementStyleProps, ImageElementStyles>;
+  getImageUrl?: () => Promise<string>;
 }
 
 // renderElement props

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -297,7 +297,7 @@ export const initialValueImages: SlateDocument = [
         children: [
           {
             text:
-              'This example shows images in action. It features two ways to add images. You can either add an image via the toolbar icon above, or if you want in on a little secret, copy an image URL to your keyboard and paste it anywhere in the editor!',
+              'This example shows images in action. It features two ways to add images. You can either add an image via the toolbar icon above, or if you want in on a little secret, copy an image URL to your keyboard and paste it anywhere in the editor! Additionally, you can customize the toolbar button to load an url asynchronously, for example showing a file picker and uploading a file to Amazon S3.',
           },
         ],
       },


### PR DESCRIPTION
## Issue

Image Upload is hard to be solved for a general use-case, the one provided by `withImageUpload` puts the content of the image into the model, which is problematic for  images event with a trivial size. 

## What I did

Provided a `getImageUrl` prop to the `ToolbarImage`, which allows getting the url in an async manner, allowing e.g. opening a file picker, uploading it to `S3` and returning the public url at the end, to insert it into the model. 

### Ideas for improvement
- display an upload indicator
- make it work with drag-n-drop too

## Checklist

- [ ] The new code matches the existing patterns and styles.
- [ ] The stories still work (run `yarn storybook`).
- [ ] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->