### PR TITLE
Add component wrapper for renderElement and renderLeaf calls.

### DIFF
--- a/packages/core/src/utils/renderElementPlugins.tsx
+++ b/packages/core/src/utils/renderElementPlugins.tsx
@@ -5,20 +5,27 @@ import { RenderElement, SlatePlugin } from '../types';
 export const renderElementPlugins = (
   plugins: SlatePlugin[],
   renderElementList: RenderElement[]
-) => (elementProps: RenderElementProps) => {
-  let element;
+) => {
+  const Tag = (elementProps: RenderElementProps) => {
+    let element;
 
-  renderElementList.some((renderElement) => {
-    element = renderElement(elementProps);
-    return !!element;
-  });
-  if (element) return element;
+    renderElementList.some((renderElement) => {
+      element = renderElement(elementProps);
+      return !!element;
+    });
+    if (element) return element;
 
-  plugins.some(({ renderElement }) => {
-    element = renderElement && renderElement(elementProps);
-    return !!element;
-  });
-  if (element) return element;
+    plugins.some(({ renderElement }) => {
+      element = renderElement && renderElement(elementProps);
+      return !!element;
+    });
+    if (element) return element;
 
-  return <div {...elementProps.attributes}>{elementProps.children}</div>;
+    return <div {...elementProps.attributes}>{elementProps.children}</div>;
+  };
+
+  return (elementProps: RenderElementProps) => {
+    // XXX: A wrapper tag component to make useContext get correct value inside.
+    return <Tag {...elementProps} />;
+  };
 };

--- a/packages/core/src/utils/renderLeafPlugins.tsx
+++ b/packages/core/src/utils/renderLeafPlugins.tsx
@@ -5,15 +5,23 @@ import { RenderLeaf, SlatePlugin } from '../types';
 export const renderLeafPlugins = (
   plugins: SlatePlugin[],
   renderLeafList: RenderLeaf[]
-) => (leafProps: RenderLeafProps) => {
-  renderLeafList.forEach((renderLeaf) => {
-    leafProps.children = renderLeaf(leafProps);
-  });
+) => {
+  const Tag = (props: RenderLeafProps) => {
+    const leafProps: RenderLeafProps = {...props}; // workaround for children readonly error.
+    renderLeafList.forEach((renderLeaf) => {
+      leafProps.children = renderLeaf(leafProps);
+    });
 
-  plugins.forEach(({ renderLeaf }) => {
-    if (!renderLeaf) return;
-    leafProps.children = renderLeaf(leafProps);
-  });
+    plugins.forEach(({ renderLeaf }) => {
+      if (!renderLeaf) return;
+      leafProps.children = renderLeaf(leafProps);
+    });
 
-  return <span {...leafProps.attributes}>{leafProps.children}</span>;
+    return <span {...leafProps.attributes}>{leafProps.children}</span>;
+  };
+
+  return (leafProps: RenderLeafProps) => {
+    // XXX: A wrapper tag component to make useContext get correct value inside.
+    return <Tag {...leafProps} />;
+  };
 };


### PR DESCRIPTION
## Issue
#403


## What I did
Wrap renderElement and renderLeaf with a Tag component wrapper, so all useContext call specially useSelected can get the correct value in the render function.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->