### PR TITLE
extending mention onclick param 

### DIFF
--- a/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
+++ b/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
@@ -45,7 +45,7 @@ export const MentionElementBase = ({
       data-slate-value={element.value}
       className={classNames.root}
       contentEditable={false}
-      onClick={getHandler(onClick, { value: element.value })}
+      onClick={getHandler(onClick, element)}
       {...htmlAttributes}
     >
       {prefix}

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -41,7 +41,7 @@ export interface MentionRenderElementPropsOptions {
    * Prefix rendered before mention
    */
   prefix?: string;
-  onClick?: ({ value }: { value: string }) => void;
+  onClick?: (mentionNode: MentionNode) => void;
 }
 
 // renderElement props


### PR DESCRIPTION
## Issue
The onClick handler only works as a PoC at the moment, the value in itself allows only a limited functionality. 


## What I did
mentionNode is passed to onClick, to support arbitrary actions based on other props.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->