### PR TITLE
enable tab/shift-tab between table cells

### DIFF
--- a/packages/slate-plugins/src/elements/table/TablePlugin.ts
+++ b/packages/slate-plugins/src/elements/table/TablePlugin.ts
@@ -1,5 +1,6 @@
 import { SlatePlugin } from '@udecode/slate-plugins-core';
 import { deserializeTable } from './deserializeTable';
+import { onKeyDownTable } from './onKeyDownTable';
 import { renderElementTable } from './renderElementTable';
 import { TablePluginOptions } from './types';
 
@@ -9,4 +10,5 @@ import { TablePluginOptions } from './types';
 export const TablePlugin = (options?: TablePluginOptions): SlatePlugin => ({
   renderElement: renderElementTable(options),
   deserialize: deserializeTable(options),
+  onKeyDown: onKeyDownTable(options),
 });

--- a/packages/slate-plugins/src/elements/table/onKeyDownTable.ts
+++ b/packages/slate-plugins/src/elements/table/onKeyDownTable.ts
@@ -1,0 +1,45 @@
+import { Editor, Transforms } from 'slate';
+import { getNextTableCell } from './queries/getNextTableCell';
+import { getPreviousTableCell } from './queries/getPreviousTableCell';
+import { getTableCellEntry } from './queries/getTableCellEntry';
+import { TableHotKey, TableOnKeyDownOptions } from './types';
+
+export const onKeyDownTable = (options?: TableOnKeyDownOptions) => (
+  e: KeyboardEvent,
+  editor: Editor
+) => {
+  if (e.key === TableHotKey.TAB) {
+    e.preventDefault();
+    const res = getTableCellEntry(editor, {}, options);
+    if (!res) return;
+    const { tableRow, tableCell } = res;
+    const [, tableCellPath] = tableCell;
+    const shiftTab = e.shiftKey;
+    const tab = !e.shiftKey;
+    if (shiftTab) {
+      // move left with shift+tab
+      const previousCell = getPreviousTableCell(
+        editor,
+        tableCell,
+        tableCellPath,
+        tableRow
+      );
+      if (previousCell) {
+        const [, previousCellPath] = previousCell;
+        Transforms.select(editor, previousCellPath);
+      }
+    } else if (tab) {
+      // move right with tab
+      const nextCell = getNextTableCell(
+        editor,
+        tableCell,
+        tableCellPath,
+        tableRow
+      );
+      if (nextCell) {
+        const [, nextCellPath] = nextCell;
+        Transforms.select(editor, nextCellPath);
+      }
+    }
+  }
+};

--- a/packages/slate-plugins/src/elements/table/queries/getCellInNextTableRow.ts
+++ b/packages/slate-plugins/src/elements/table/queries/getCellInNextTableRow.ts
@@ -1,0 +1,20 @@
+import { Ancestor, Editor, NodeEntry, Path } from 'slate';
+
+export function getCellInNextTableRow(
+  editor: Editor,
+  currentRowPath: Path
+): NodeEntry | undefined {
+  try {
+    const nextRow = Editor.node(editor, Path.next(currentRowPath)) as NodeEntry<
+      Ancestor
+    >;
+    // TODO: Many tables in rich text editors (Google Docs, Word),
+    // add a new row if we're in the last cell. Should we do the same?
+    const [nextRowNode, nextRowPath] = nextRow;
+    const nextCell = nextRowNode?.children?.[0];
+    const nextCellPath = nextRowPath.concat(0);
+    if (nextCell && nextCellPath) {
+      return Editor.node(editor, nextCellPath);
+    }
+  } catch (err) {}
+}

--- a/packages/slate-plugins/src/elements/table/queries/getCellInPreviousTableRow.ts
+++ b/packages/slate-plugins/src/elements/table/queries/getCellInPreviousTableRow.ts
@@ -1,0 +1,22 @@
+import { Ancestor, Editor, NodeEntry, Path } from 'slate';
+
+export function getCellInPreviousTableRow(
+  editor: Editor,
+  currentRowPath: Path
+): NodeEntry | undefined {
+  try {
+    const previousRow = Editor.node(
+      editor,
+      Path.previous(currentRowPath)
+    ) as NodeEntry<Ancestor>;
+    const [previousRowNode, previousRowPath] = previousRow;
+    const previousCell =
+      previousRowNode?.children?.[previousRowNode.children.length - 1];
+    const previousCellPath = previousRowPath.concat(
+      previousRowNode.children.length - 1
+    );
+    if (previousCell && previousCellPath) {
+      return Editor.node(editor, previousCellPath);
+    }
+  } catch (err) {}
+}

--- a/packages/slate-plugins/src/elements/table/queries/getNextTableCell.ts
+++ b/packages/slate-plugins/src/elements/table/queries/getNextTableCell.ts
@@ -1,0 +1,16 @@
+import { Editor, NodeEntry, Path } from 'slate';
+import { getCellInNextTableRow } from './getCellInNextTableRow';
+
+export function getNextTableCell(
+  editor: Editor,
+  currentCell: NodeEntry,
+  currentPath: Path,
+  currentRow: NodeEntry
+): NodeEntry | undefined {
+  try {
+    return Editor.node(editor, Path.next(currentPath));
+  } catch (err) {
+    const [, currentRowPath] = currentRow;
+    return getCellInNextTableRow(editor, currentRowPath);
+  }
+}

--- a/packages/slate-plugins/src/elements/table/queries/getPreviousTableCell.ts
+++ b/packages/slate-plugins/src/elements/table/queries/getPreviousTableCell.ts
@@ -1,0 +1,16 @@
+import { Editor, NodeEntry, Path } from 'slate';
+import { getCellInPreviousTableRow } from './getCellInPreviousTableRow';
+
+export function getPreviousTableCell(
+  editor: Editor,
+  currentCell: NodeEntry,
+  currentPath: Path,
+  currentRow: NodeEntry
+): NodeEntry | undefined {
+  try {
+    return Editor.node(editor, Path.previous(currentPath));
+  } catch (err) {
+    const [, currentRowPath] = currentRow;
+    return getCellInPreviousTableRow(editor, currentRowPath);
+  }
+}

--- a/packages/slate-plugins/src/elements/table/queries/getTableCellEntry.ts
+++ b/packages/slate-plugins/src/elements/table/queries/getTableCellEntry.ts
@@ -1,0 +1,49 @@
+import { Editor, Location } from 'slate';
+import { setDefaults } from '../../../common';
+import { getAboveByType } from '../../../common/queries/getAboveByType';
+import { getParent } from '../../../common/queries/getParent';
+import { isNodeTypeIn } from '../../../common/queries/isNodeTypeIn';
+import { DEFAULTS_TABLE } from '../defaults';
+import { TableOptions } from '../types';
+
+/**
+ * If at (default = selection) is in table>tr>td, return table, tr, and td
+ * node entries.
+ */
+export const getTableCellEntry = (
+  editor: Editor,
+  { at = editor.selection }: { at?: Location | null } = {},
+  options?: TableOptions
+) => {
+  const { td, tr, table } = setDefaults(options, DEFAULTS_TABLE);
+
+  if (at && isNodeTypeIn(editor, td.type, { at })) {
+    const selectionParent = getParent(editor, at);
+    if (!selectionParent) return;
+    const [, paragraphPath] = selectionParent;
+
+    const tableCell =
+      getAboveByType(editor, td.type, { at }) ||
+      getParent(editor, paragraphPath);
+
+    if (!tableCell) return;
+    const [tableCellNode, tableCellPath] = tableCell;
+
+    if (tableCellNode.type !== td.type) return;
+
+    const tableRow = getParent(editor, tableCellPath);
+    if (!tableRow) return;
+    const [tableRowNode, tableRowPath] = tableRow;
+
+    if (tableRowNode.type !== tr.type) return;
+
+    const tableElement = getParent(editor, tableRowPath);
+    if (!table) return;
+
+    return {
+      tableElement,
+      tableRow,
+      tableCell,
+    };
+  }
+};

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -11,6 +11,10 @@ import {
   RootProps,
 } from '../../common/types/PluginOptions.types';
 
+export const TableHotKey = {
+  TAB: 'Tab',
+};
+
 // Data of Element node
 export interface TableNodeData {}
 // Element node
@@ -54,8 +58,9 @@ export interface TableRenderElementOptions
 export interface TableDeserializeOptions
   extends TablePluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
-export interface WithTableOptions extends TablePluginOptions<'type'> {}
+export interface TableOnKeyDownOptions extends TablePluginOptions<'type'> {}
 export interface TableOptions extends TablePluginOptions<'type'> {}
+export interface WithTableOptions extends TablePluginOptions<'type'> {}
 
 export interface TableElementStyles {
   /**


### PR DESCRIPTION
## Issue

When in a table cell, tab and shift-tab are common keyboard shortcuts to move to next or previous cell.

## What I did

Added an `onKeyDown` handler for tables following the pattern for the list plugin, along with helpers to get the current and next/previous cell and logic to handle start/end of row and table.

Note: I have not written tests as I don't quite follow the syntax for the similar tests for lists. I could use help with that, or some guidance if possible. Thanks!

Note: Many rich text editors add a new row if you press tab in the last cell of a table. I did not implement this but left a TODO. If this is desired behavior it should be pretty easy to add.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.
