### PR TITLE
Fix split list item failure.

### DIFF
--- a/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
@@ -57,18 +57,20 @@ export const insertListItem = (editor: Editor, options?: ListOptions) => {
      * If not end, split nodes, wrap a list item on the new paragraph and move it to the next list item
      */
     if (!isEnd) {
-      Transforms.splitNodes(editor, { at: editor.selection });
-      Transforms.wrapNodes(
-        editor,
-        {
-          type: li.type,
-          children: [],
-        },
-        { at: nextParagraphPath }
-      );
-      Transforms.moveNodes(editor, {
-        at: nextParagraphPath,
-        to: nextListItemPath,
+      Editor.withoutNormalizing(editor, () => {
+        Transforms.splitNodes(editor);
+        Transforms.wrapNodes(
+          editor,
+          {
+            type: li.type,
+            children: [],
+          },
+          { at: nextParagraphPath }
+        );
+        Transforms.moveNodes(editor, {
+          at: nextParagraphPath,
+          to: nextListItemPath,
+        });
       });
     } else {
       /**


### PR DESCRIPTION
## Issue
List item split failure


## What I did
wrap the 3 operations with Editor.withoutNormalizing

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->