### PR TITLE
Prevent double delete fragment.

### DIFF
--- a/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/deleteListFragment.ts
@@ -29,6 +29,7 @@ export const deleteListFragment = (
   const [rootNode, rootPath] = root;
   const { li } = setDefaults(options, DEFAULTS_LIST);
   let moved = 0;
+  let deleted = false;
 
   Editor.withoutNormalizing(editor, () => {
     const listEnd = getListItemEntry(editor, { at: endSelection }, options);
@@ -54,7 +55,7 @@ export const deleteListFragment = (
       );
 
       const toListNode = getNode(editor, next);
-      if (!toListNode) return 0;
+      if (!toListNode) return;
 
       childrenMoved = moveListItemSublistItemsToList(
         editor,
@@ -115,8 +116,9 @@ export const deleteListFragment = (
     // Move done. We can delete the fragment.
     Transforms.delete(editor, { at: selection });
 
+    deleted = true;
     moved = siblingsMoved + childrenMoved;
   });
 
-  return moved;
+  return deleted ? moved : undefined;
 };

--- a/packages/slate-plugins/src/elements/list/withList.ts
+++ b/packages/slate-plugins/src/elements/list/withList.ts
@@ -162,7 +162,7 @@ export const withList = ({
       Editor.withoutNormalizing(editor, () => {
         deleted = deleteListFragment(editor, selection, options);
       });
-      if (deleted) return;
+      if (deleted !== undefined) return;
     }
 
     deleteFragment();


### PR DESCRIPTION
## Issue
create a two-item list, then select the two items, delete, this will not only delete the list item content, also will cause the list be deleted. which is because internally, the deleteFragment is called again after the list content delete, due to the return value check.


## What I did
Adjust the return value check of deleteListFragment, and also make sure it return undefined if it did not call transform 'delete'.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->