### PR TITLE
fixes #350, markdown deserialize link property

### DIFF
--- a/packages/slate-plugins/package.json
+++ b/packages/slate-plugins/package.json
@@ -38,7 +38,7 @@
     "react-dnd-html5-backend": "^11.1.3",
     "react-use": "^15.1.0",
     "remark-parse": "^9.0.0",
-    "remark-slate": "^1.1.1",
+    "remark-slate": "^1.4.0",
     "unified": "^9.1.0",
     "utility-types": "^3.10.0"
   },

--- a/packages/slate-plugins/src/deserializers/deserialize-md/utils/parseMD.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-md/utils/parseMD.ts
@@ -12,7 +12,7 @@ import {
   ELEMENT_H5,
   ELEMENT_H6,
 } from '../../../elements/heading/defaults';
-import { ELEMENT_LINK } from '../../../elements/link/defaults';
+import { ATTRIBUTE_LINK, ELEMENT_LINK } from '../../../elements/link/defaults';
 import {
   ELEMENT_LI,
   ELEMENT_OL,
@@ -38,7 +38,7 @@ export const parseMD = (options?: Record<string, any>) => (content: string) => {
   } = setDefaults(options, {
     p: { type: ELEMENT_PARAGRAPH },
     blockquote: { type: ELEMENT_BLOCKQUOTE },
-    link: { type: ELEMENT_LINK },
+    link: { type: ELEMENT_LINK, attribute: ATTRIBUTE_LINK },
     code: { type: ELEMENT_CODE_BLOCK },
     ul: { type: ELEMENT_UL },
     ol: { type: ELEMENT_OL },
@@ -71,6 +71,7 @@ export const parseMD = (options?: Record<string, any>) => (content: string) => {
           6: h6.type,
         },
       },
+      linkDestinationKey: link.attribute,
     })
     .processSync(content);
 

--- a/packages/slate-plugins/src/elements/link/defaults.ts
+++ b/packages/slate-plugins/src/elements/link/defaults.ts
@@ -3,11 +3,13 @@ import { LinkElement } from './components/LinkElement';
 import { LinkKeyOption, LinkPluginOptionsValues } from './types';
 
 export const ELEMENT_LINK = 'a';
+export const ATTRIBUTE_LINK = 'url';
 
 export const DEFAULTS_LINK: Record<LinkKeyOption, LinkPluginOptionsValues> = {
   link: {
     component: LinkElement,
     type: ELEMENT_LINK,
+    attribute: ATTRIBUTE_LINK,
     isUrl,
     rootProps: {
       className: 'slate-link',

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -54,6 +54,7 @@ export type LinkPluginOptionsValues = RenderNodeOptions &
      * Callback to validate an url.
      */
     isUrl?: (text: string) => boolean;
+    attribute?: string;
   };
 export type LinkPluginOptionsKeys = keyof LinkPluginOptionsValues;
 export type LinkPluginOptions<

--- a/yarn.lock
+++ b/yarn.lock
@@ -15804,10 +15804,10 @@ remark-parse@^9.0.0:
   dependencies:
     mdast-util-from-markdown "^0.8.0"
 
-remark-slate@^1.1.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/remark-slate/-/remark-slate-1.2.2.tgz#86b2487fe5ffdcf2c39072ed29727daa94e8358d"
-  integrity sha512-2m8BVNUypma1PZ5H/XBrh160hndBEXgRSqTTG/DUKEeaZBwBWiYcCCjkDse7PDjIwiRYVALQxhABWA2nbhVXYw==
+remark-slate@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/remark-slate/-/remark-slate-1.4.0.tgz#d546e4eab254d7d896a80c56c7f45e071bc2227b"
+  integrity sha512-L+/rXpb//aVD/O5jNXR663NbNwHMqlIey22FJfSt0uXRE+vfjd8TBomt14glx6TjLwuqwBUbbLm45KLRLb+sog==
   dependencies:
     "@types/escape-html" "^1.0.0"
     escape-html "^1.0.3"


### PR DESCRIPTION
## Issue

The markdown parser parses links and sets a link property rather than a url property (#350)

## What I did

* Update to 1.4.0 of 'remark-slate' which recently added a `linkDestinationKey`
* Update slate-plugins defaults to make it easier to override the default
* Update `parseMD` to specify the `linkDestinationKey` based on defaults + options


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.