### PR TITLE
Allow renderElement call next() to wrap other render result.

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,7 +21,8 @@ export type OnDOMBeforeInput = (event: Event, editor: Editor) => void;
  * Return undefined in case the criteria for rendering isn't met
  */
 export type RenderElement = (
-  props: RenderElementProps
+  props: RenderElementProps,
+  next?: () => JSX.Element
 ) => JSX.Element | undefined;
 
 /**

--- a/packages/core/src/utils/renderElementPlugins.tsx
+++ b/packages/core/src/utils/renderElementPlugins.tsx
@@ -7,21 +7,35 @@ export const renderElementPlugins = (
   renderElementList: RenderElement[]
 ) => {
   const Tag = (elementProps: RenderElementProps) => {
-    let element;
+    let renderIdx = 0;
 
-    renderElementList.some((renderElement) => {
-      element = renderElement(elementProps);
-      return !!element;
-    });
-    if (element) return element;
+    const next = () => {
+      let element;
 
-    plugins.some(({ renderElement }) => {
-      element = renderElement && renderElement(elementProps);
-      return !!element;
-    });
-    if (element) return element;
+      renderElementList.some((renderElement, idx) => {
+        if (idx < renderIdx) {
+          return false;
+        }
+        renderIdx += 1;
+        element = renderElement(elementProps, next);
+        return !!element;
+      });
+      if (element) return element;
 
-    return <div {...elementProps.attributes}>{elementProps.children}</div>;
+      plugins.some(({ renderElement }, idx) => {
+        if (renderElementList.length + idx < renderIdx) {
+          return false;
+        }
+        renderIdx += 1;
+        element = renderElement && renderElement(elementProps, next);
+        return !!element;
+      });
+      if (element) return element;
+
+      return <div {...elementProps.attributes} {...elementProps.element?.attributes}>{elementProps.children}</div>;
+    }
+
+    return next();
   };
 
   return (elementProps: RenderElementProps) => {


### PR DESCRIPTION
## Issue
renderElement can only render by itself, can not wrap other 'type's render result. e.g. add selectable, draggable, context, etc.


## What I did
refactor the renderElementPlugins method, so it supply one more parameter 'next' to renderElement handlers, so that any renderElement handler can do some wrap work like:
```
return <Wrapper>{next()}</Wrapper>
```


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [ ] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->