### PR TITLE
Improve useMention to work with accents

### DIFF
--- a/packages/slate-plugins/src/common/__tests__/queries/isWordAfterTrigger/trigger-accent.spec.tsx
+++ b/packages/slate-plugins/src/common/__tests__/queries/isWordAfterTrigger/trigger-accent.spec.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+
+import { Editor, Range } from 'slate';
+import { jsx } from '../../../../__test-utils__/jsx';
+import { isWordAfterTrigger } from '../../../queries/index';
+
+const input = ((
+  <editor>
+    <hp>
+      @pré
+      <cursor /> test2
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const at = Range.start(input.selection as Range);
+
+const output = 'pré';
+
+it('should be', () => {
+  expect(isWordAfterTrigger(input, { at, trigger: '@' }).match?.[1]).toBe(
+    output
+  );
+});

--- a/packages/slate-plugins/src/common/queries/isWordAfterTrigger.ts
+++ b/packages/slate-plugins/src/common/queries/isWordAfterTrigger.ts
@@ -24,7 +24,8 @@ export const isWordAfterTrigger = (
 
   // Starts with char and ends with word characters
   const escapedTrigger = escapeRegExp(trigger);
-  const beforeRegex = new RegExp(`^${escapedTrigger}(\\w+)$`);
+
+  const beforeRegex = new RegExp(`^${escapedTrigger}([\\w|À-ÖØ-öø-ÿ]+)$`);
 
   // Match regex on before text
   const match = !!beforeText && beforeText.match(beforeRegex);


### PR DESCRIPTION
## Issue

When using useMention, if the variable names have accents in it, the RegExp won't match them. Eg. in French: 
| @pr | @pré |
| ---- | ------|
| ![image](https://user-images.githubusercontent.com/445045/104315633-89b76280-54db-11eb-8cd4-7d46620d220e.png) | ![image](https://user-images.githubusercontent.com/445045/104315663-91770700-54db-11eb-9cff-9f7e20d1761f.png) |


## What I did
Tweak the RegExp so that accents characters are taken into accounts.
I've followed this RegExp pattern: https://stackoverflow.com/a/26900132

I could've used `\S` like in this example: https://codesandbox.io/s/mentions-forked-06ctt?file=/src/index.js:576-585, which is a non blank character, but thought of just adding accents for now.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->