### PR TITLE
optional array of classname prefixes to preserve from `stripClassNames`

### DIFF
--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/classNames.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/classNames.spec.ts
@@ -107,3 +107,45 @@ it('serialize with slate classNames: multiple tags', () => {
     '<div class="slate-align-center">I am centered text!</div><div class="slate-align-center">I am centered text!</div>'
   );
 });
+
+it('serialize with custom preserved classname: a+custom', () => {
+  expect(
+    serializeHTMLFromNodes({
+      plugins: [
+        AlignPlugin({
+          align_center: {
+            rootProps: {
+              className: 'a custom-align-center slate-align-center',
+            },
+          },
+        }),
+      ],
+      nodes: [
+        { type: 'align_center', children: [{ text: 'I am centered text!' }] },
+      ],
+      preserveClassNames: ['custom-'],
+    })
+  ).toBe('<div class="custom-align-center">I am centered text!</div>');
+});
+
+it('serialize with multiple custom classname: a+custom+slate', () => {
+  expect(
+    serializeHTMLFromNodes({
+      plugins: [
+        AlignPlugin({
+          align_center: {
+            rootProps: {
+              className: 'a custom-align-center slate-align-center',
+            },
+          },
+        }),
+      ],
+      nodes: [
+        { type: 'align_center', children: [{ text: 'I am centered text!' }] },
+      ],
+      preserveClassNames: ['custom-', 'slate-'],
+    })
+  ).toBe(
+    '<div class="custom-align-center slate-align-center">I am centered text!</div>'
+  );
+});


### PR DESCRIPTION
## Issue

When deserializing html from various sources, a custom plugin could rely on a unique classname to match into that custom type.  Subsequently, when serializing that custom node, we would expect to be able to preserve that classname

```
<div class="spoiler">This text is a spoiler</div>
```
↕️
```
getElementDeserializer({
  type: 'spoiler',
  rules: [{ className: 'spoiler' }],
})
```
However, when using `serializeHTMLFromNodes`, all class names that are not `slate-` are stripped away.

## What I did

Add a new optional `preserveClassNames` property to `serializeHTMLFromNodes` that allows one to opt-in other class names or class prefixes to be preserved from `stripClassNames`

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->