### PR TITLE
fix not passing preserveClassNames recursively

### DIFF
--- a/packages/slate-plugins/src/serializers/serialize-html/__tests__/classNames.spec.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/__tests__/classNames.spec.ts
@@ -1,4 +1,5 @@
 import { AlignPlugin } from '../../../elements/align/AlignPlugin';
+import { BoldPlugin } from '../../../marks/bold/BoldPlugin';
 import { serializeHTMLFromNodes } from '../serializeHTMLFromNodes';
 
 it('serialize with slate className', () => {
@@ -126,6 +127,42 @@ it('serialize with custom preserved classname: a+custom', () => {
       preserveClassNames: ['custom-'],
     })
   ).toBe('<div class="custom-align-center">I am centered text!</div>');
+});
+
+it('serialize nested with custom preserved classname: a+custom', () => {
+  expect(
+    serializeHTMLFromNodes({
+      plugins: [
+        AlignPlugin({
+          align_center: {
+            rootProps: {
+              className: 'a custom-align-center slate-align-center',
+            },
+          },
+        }),
+        BoldPlugin({
+          bold: {
+            rootProps: {
+              className: 'custom-bold',
+            },
+          },
+        }),
+      ],
+      nodes: [
+        {
+          type: 'align_center',
+          children: [
+            { text: 'I am ' },
+            { text: 'centered', bold: true },
+            { text: ' text!' },
+          ],
+        },
+      ],
+      preserveClassNames: ['custom-'],
+    })
+  ).toBe(
+    '<div class="custom-align-center">I am <strong class="custom-bold">centered</strong> text!</div>'
+  );
 });
 
 it('serialize with multiple custom classname: a+custom+slate', () => {

--- a/packages/slate-plugins/src/serializers/serialize-html/serializeHTMLFromNodes.ts
+++ b/packages/slate-plugins/src/serializers/serialize-html/serializeHTMLFromNodes.ts
@@ -201,6 +201,7 @@ export const serializeHTMLFromNodes = ({
             serializeHTMLFromNodes({
               plugins,
               nodes: node.children,
+              preserveClassNames,
             })
           ),
           attributes: { 'data-slate-node': 'element', ref: null },


### PR DESCRIPTION
## Issue

In the previous PR, `preserveClassNames` was not passed through when `serializeHTMLFromNodes` was called recursively for the children nodes.

## What I did

Passed through `preserveClassNames` and added a test to verify

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->