### PR TITLE
CodeBlock plugin: decorate now supports overriding the AST type

### DIFF
--- a/packages/slate-plugins/src/elements/code-block/decorateCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/decorateCodeBlock.ts
@@ -45,13 +45,18 @@
 // import 'prismjs/components/prism-yaml';
 import { languages, Token, tokenize } from 'prismjs';
 import { Node, NodeEntry } from 'slate';
-import { ELEMENT_CODE_BLOCK } from './defaults';
+import { setDefaults } from '../../common/utils/setDefaults';
+import { DEFAULTS_CODE_BLOCK } from './defaults';
+import { CodeBlockDeserializeOptions } from './types';
 
-export const decorateCodeBlock = () => (entry: NodeEntry) => {
+export const decorateCodeBlock = (options?: CodeBlockDeserializeOptions) => (
+  entry: NodeEntry
+) => {
   const ranges: any = [];
   const [node, path] = entry;
+  const { code_block } = setDefaults(options, DEFAULTS_CODE_BLOCK);
 
-  if (node.type === ELEMENT_CODE_BLOCK) {
+  if (node.type === code_block.type) {
     const text = Node.string(node);
     // const langName: any = parent.lang || 'markup';
     const langName: any = 'javascript';

--- a/packages/slate-plugins/src/elements/code-block/decorateCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/decorateCodeBlock.ts
@@ -47,9 +47,9 @@ import { languages, Token, tokenize } from 'prismjs';
 import { Node, NodeEntry } from 'slate';
 import { setDefaults } from '../../common/utils/setDefaults';
 import { DEFAULTS_CODE_BLOCK } from './defaults';
-import { CodeBlockDeserializeOptions } from './types';
+import { CodeBlockDecorateOptions } from './types';
 
-export const decorateCodeBlock = (options?: CodeBlockDeserializeOptions) => (
+export const decorateCodeBlock = (options?: CodeBlockDecorateOptions) => (
   entry: NodeEntry
 ) => {
   const ranges: any = [];

--- a/packages/slate-plugins/src/elements/code-block/types.ts
+++ b/packages/slate-plugins/src/elements/code-block/types.ts
@@ -61,6 +61,9 @@ export interface CodeBlockRenderElementOptions
 export interface CodeBlockDeserializeOptions
   extends CodeBlockPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
+export interface CodeBlockDecorateOptions
+  extends CodeBlockPluginOptions<'type'> {}
+
 export interface CodeBlockElementStyles {
   /**
    * Style for the root element.


### PR DESCRIPTION
## Issue

The decorate method for the CodeBlock plugin was not supporting options to override the default AST type

## What I did

Following the pattern of other similar methods, the decorate method now reads the options and overrides the defaults.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.