### PR TITLE
fix: moveListItemUp add withoutNormalizing #454

### DIFF
--- a/packages/slate-plugins/src/elements/list/transforms/moveListItemUp.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/moveListItemUp.ts
@@ -29,53 +29,55 @@ export const moveListItemUp = (
 
   if (listParentNode.type !== li.type) return;
 
-  const newListItemPath = Path.next(listParentPath);
+  Editor.withoutNormalizing(editor, () => {
+    const newListItemPath = Path.next(listParentPath);
 
-  // Move item one level up
-  Transforms.moveNodes(editor, {
-    at: listItemPath,
-    to: newListItemPath,
-  });
+    // Move item one level up
+    Transforms.moveNodes(editor, {
+      at: listItemPath,
+      to: newListItemPath,
+    });
 
-  /**
-   * Move the next siblings to a new list
-   */
-  const listItemIdx = listItemPath[listItemPath.length - 1];
-  const siblingPath = [...listItemPath];
-  const newListPath = newListItemPath.concat(1);
-  let siblingFound = false;
-  let newSiblingIdx = 0;
-  listNode.children.forEach((n, idx) => {
-    if (listItemIdx < idx) {
-      if (!siblingFound) {
-        siblingFound = true;
+    /**
+     * Move the next siblings to a new list
+     */
+    const listItemIdx = listItemPath[listItemPath.length - 1];
+    const siblingPath = [...listItemPath];
+    const newListPath = newListItemPath.concat(1);
+    let siblingFound = false;
+    let newSiblingIdx = 0;
+    listNode.children.forEach((n, idx) => {
+      if (listItemIdx < idx) {
+        if (!siblingFound) {
+          siblingFound = true;
 
-        Transforms.insertNodes(
-          editor,
-          {
-            type: listNode.type,
-            children: [],
-          },
-          { at: newListPath }
-        );
+          Transforms.insertNodes(
+            editor,
+            {
+              type: listNode.type,
+              children: [],
+            },
+            { at: newListPath }
+          );
+        }
+
+        siblingPath[siblingPath.length - 1] = listItemIdx;
+        const newSiblingsPath = newListPath.concat(newSiblingIdx);
+        newSiblingIdx++;
+        Transforms.moveNodes(editor, {
+          at: siblingPath,
+          to: newSiblingsPath,
+        });
       }
+    });
 
-      siblingPath[siblingPath.length - 1] = listItemIdx;
-      const newSiblingsPath = newListPath.concat(newSiblingIdx);
-      newSiblingIdx++;
-      Transforms.moveNodes(editor, {
-        at: siblingPath,
-        to: newSiblingsPath,
+    // Remove sublist if it was the first list item
+    if (!listItemIdx) {
+      Transforms.removeNodes(editor, {
+        at: listPath,
       });
     }
   });
-
-  // Remove sublist if it was the first list item
-  if (!listItemIdx) {
-    Transforms.removeNodes(editor, {
-      at: listPath,
-    });
-  }
 
   return true;
 };


### PR DESCRIPTION
fix Enter in sublistitem error

## Issue
#454 

## What I did

add withoutNormalizing

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.
