### PR TITLE
update render leaf plugins to be more similar renderElementPlugins

### DIFF
--- a/packages/core/src/utils/renderLeafPlugins.tsx
+++ b/packages/core/src/utils/renderLeafPlugins.tsx
@@ -6,22 +6,26 @@ export const renderLeafPlugins = (
   plugins: SlatePlugin[],
   renderLeafList: RenderLeaf[]
 ) => {
-  const Tag = (props: RenderLeafProps) => {
-    const leafProps: RenderLeafProps = { ...props }; // workaround for children readonly error.
-    renderLeafList.forEach((renderLeaf) => {
-      leafProps.children = renderLeaf(leafProps);
-    });
+  const Tag = (leafProps: RenderLeafProps) => {
+    let leaf;
 
-    plugins.forEach(({ renderLeaf }) => {
-      if (!renderLeaf) return;
-      leafProps.children = renderLeaf(leafProps);
+    renderLeafList.some((renderLeaf) => {
+      leaf = renderLeaf(leafProps);
+      return !!leaf;
     });
+    if (leaf) return leaf;
+
+    plugins.some(({ renderLeaf }) => {
+      leaf = renderLeaf && renderLeaf(leafProps);
+      return !!leaf;
+    });
+    if (leaf) return leaf;
 
     return <span {...leafProps.attributes}>{leafProps.children}</span>;
   };
 
-  return (leafProps: RenderLeafProps) => {
+  return (elementProps: RenderLeafProps) => {
     // XXX: A wrapper tag component to make useContext get correct value inside.
-    return <Tag {...leafProps} />;
+    return <Tag {...elementProps} />;
   };
 };


### PR DESCRIPTION
## Issue

#458 

## What I did

Update the implementation of renderLeaf to reflect returning the entire leaf not just the leaf children.

## Checklist

Need to confirm that this works with existing plugins. It seems to be ok but it may be a breaking change if the attributes are not being rendered on certain calls to render leaf.

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->