### PR TITLE
Unwrap links when entering an empty URL in the prompt

### DIFF
--- a/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
+++ b/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { Transforms } from 'slate';
 import { useSlate } from 'slate-react';
+import { unwrapNodes } from '../../../common';
 import { getAbove, isCollapsed } from '../../../common/queries';
 import { someNode } from '../../../common/queries/someNode';
 import { setDefaults } from '../../../common/utils/setDefaults';
@@ -33,7 +35,16 @@ export const ToolbarLink = ({
           prevUrl = linkNode[0].url as string;
         }
         const url = window.prompt(`Enter the URL of the link:`, prevUrl);
-        if (!url) return;
+        if (!url) {
+          linkNode &&
+            editor.selection &&
+            unwrapNodes(editor, {
+              at: editor.selection,
+              match: { type: options.link.type },
+            });
+
+          return;
+        }
 
         // If our cursor is in middle of a link, then we don't want to inser it inline
         const shouldWrap: boolean =

--- a/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
+++ b/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Transforms } from 'slate';
 import { useSlate } from 'slate-react';
 import { unwrapNodes } from '../../../common';
 import { getAbove, isCollapsed } from '../../../common/queries';


### PR DESCRIPTION
## Issue
Currently, there is no way of writing down something that matches the URL regex, without having it become a link.
And also there is no way of removing a link without deleting and rewriting the text.

## What I did
When submitting an empty string in the link URL prompt, the selected node will be unwrapped from the link.
![Large GIF (896x598)](https://user-images.githubusercontent.com/10298160/106603613-30d16c00-6567-11eb-9e2d-f9f4d6984a45.gif)


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [ ] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->