### PR TITLE
Bonjour/469/display mentionable right after trigger

### DIFF
--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -1,6 +1,6 @@
-import { IStyle } from "@uifabric/styling";
-import { IStyleFunctionOrObject } from "@uifabric/utilities";
-import { RenderElementProps } from "slate-react";
+import { IStyle } from '@uifabric/styling';
+import { IStyleFunctionOrObject } from '@uifabric/utilities';
+import { RenderElementProps } from 'slate-react';
 import {
   Deserialize,
   ElementWithAttributes,
@@ -9,7 +9,7 @@ import {
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
-} from "../../common/types/PluginOptions.types";
+} from '../../common/types/PluginOptions.types';
 
 // useMention options
 export interface UseMentionOptions extends MentionPluginOptions {
@@ -60,7 +60,7 @@ export interface MentionElementProps
   element: MentionNode;
 }
 
-export type MentionKeyOption = "mention";
+export type MentionKeyOption = 'mention';
 
 // Plugin options
 export type MentionPluginOptionsValues = RenderNodeOptions &
@@ -79,9 +79,9 @@ export interface MentionRenderElementOptions
 
 // deserialize options
 export interface MentionDeserializeOptions
-  extends MentionPluginOptions<"type" | "rootProps" | "deserialize"> {}
+  extends MentionPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
 
-export interface WithMentionOptions extends MentionPluginOptions<"type"> {}
+export interface WithMentionOptions extends MentionPluginOptions<'type'> {}
 
 export interface MentionElementStyles {
   /**

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -1,6 +1,6 @@
-import { IStyle } from '@uifabric/styling';
-import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { RenderElementProps } from 'slate-react';
+import { IStyle } from "@uifabric/styling";
+import { IStyleFunctionOrObject } from "@uifabric/utilities";
+import { RenderElementProps } from "slate-react";
 import {
   Deserialize,
   ElementWithAttributes,
@@ -9,7 +9,7 @@ import {
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
-} from '../../common/types/PluginOptions.types';
+} from "../../common/types/PluginOptions.types";
 
 // useMention options
 export interface UseMentionOptions extends MentionPluginOptions {
@@ -21,6 +21,8 @@ export interface UseMentionOptions extends MentionPluginOptions {
   mentionableFilter?: (
     search: string
   ) => (mentionable: MentionNodeData) => boolean;
+  // Regex Pattern of a mentionable. Some may want to match emails, so default \W is not enough
+  mentionableSearchPattern?: string;
 }
 
 // Data of Element node
@@ -58,7 +60,7 @@ export interface MentionElementProps
   element: MentionNode;
 }
 
-export type MentionKeyOption = 'mention';
+export type MentionKeyOption = "mention";
 
 // Plugin options
 export type MentionPluginOptionsValues = RenderNodeOptions &
@@ -77,9 +79,9 @@ export interface MentionRenderElementOptions
 
 // deserialize options
 export interface MentionDeserializeOptions
-  extends MentionPluginOptions<'type' | 'rootProps' | 'deserialize'> {}
+  extends MentionPluginOptions<"type" | "rootProps" | "deserialize"> {}
 
-export interface WithMentionOptions extends MentionPluginOptions<'type'> {}
+export interface WithMentionOptions extends MentionPluginOptions<"type"> {}
 
 export interface MentionElementStyles {
   /**

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -24,16 +24,10 @@ export const MatchesTriggerAndPattern = (
   // Before text
   const beforeText = getText(editor, beforeRange);
 
-  // // Starts with char and ends with word characters
+  // Starts with char and ends with word characters
   const escapedTrigger = escapeRegExp(trigger);
 
   const beforeRegex = new RegExp(`(?:^|\\s)${escapedTrigger}(${pattern})$`);
-  console.log(
-    "🚀 ~ file: useMention.tsx ~ line 26 ~ beforeText",
-    beforeText,
-    beforeText.match(beforeRegex),
-    beforeRegex
-  );
 
   // Match regex on before text
   const match = !!beforeText && beforeText.match(beforeRegex);
@@ -124,49 +118,28 @@ export const useMention = (
       if (selection && isCollapsed(selection)) {
         const cursor = Range.start(selection);
 
-        if (!mentionableSearchPattern) {
-          // previous behavior. searches for a word after typing the first letter. Kept for backward compatibility.
-
-          const { range, match: beforeMatch } = isWordAfterTrigger(editor, {
-            at: cursor,
-            trigger,
-          });
-
-          console.log(range, beforeMatch);
-
-          if (beforeMatch && isPointAtWordEnd(editor, { at: cursor })) {
-            setTargetRange(range as Range);
-            const [, word] = beforeMatch;
-            setSearch(word);
-            setValueIndex(0);
-            return;
-          }
-
-          setTargetRange(null);
-        } else {
-          // new behavior, searches for matching string against pattern right after the trigger
-
-          const { range, match: beforeMatch } = MatchesTriggerAndPattern(
-            editor,
-            {
+        const { range, match: beforeMatch } = mentionableSearchPattern
+          ? //new behavior, searches for matching string against pattern right after the trigger
+            MatchesTriggerAndPattern(editor, {
               at: cursor,
               trigger,
               pattern: mentionableSearchPattern,
-            }
-          );
+            })
+          : // previous behavior. searches for a word after typing the first letter. Kept for backward compatibility.
+            isWordAfterTrigger(editor, {
+              at: cursor,
+              trigger,
+            });
 
-          console.log(range, beforeMatch);
-
-          if (beforeMatch && isPointAtWordEnd(editor, { at: cursor })) {
-            setTargetRange(range as Range);
-            const [, word] = beforeMatch;
-            setSearch(word);
-            setValueIndex(0);
-            return;
-          }
-
-          setTargetRange(null);
+        if (beforeMatch && isPointAtWordEnd(editor, { at: cursor })) {
+          setTargetRange(range as Range);
+          const [, word] = beforeMatch;
+          setSearch(word);
+          setValueIndex(0);
+          return;
         }
+
+        setTargetRange(null);
       }
     },
     [setTargetRange, setSearch, setValueIndex, trigger]

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -1,22 +1,22 @@
-import { useCallback, useState } from "react";
-import { Editor, Point, Range, Transforms } from "slate";
-import { escapeRegExp } from "../../common";
+import { useCallback, useState } from 'react';
+import { Editor, Point, Range, Transforms } from 'slate';
+import { escapeRegExp } from '../../common';
 import {
   getText,
   isPointAtWordEnd,
   isWordAfterTrigger,
-} from "../../common/queries";
-import { isCollapsed } from "../../common/queries/isCollapsed";
-import { insertMention } from "./transforms";
-import { MentionNodeData, UseMentionOptions } from "./types";
-import { getNextIndex, getPreviousIndex } from "./utils";
+} from '../../common/queries';
+import { isCollapsed } from '../../common/queries/isCollapsed';
+import { insertMention } from './transforms';
+import { MentionNodeData, UseMentionOptions } from './types';
+import { getNextIndex, getPreviousIndex } from './utils';
 
 export const MatchesTriggerAndPattern = (
   editor: Editor,
   { at, trigger, pattern }: { at: Point; trigger: string; pattern: string }
 ) => {
   // Point at the start of line
-  const lineStart = Editor.before(editor, at, { unit: "line" });
+  const lineStart = Editor.before(editor, at, { unit: 'line' });
 
   // Range from before to start
   const beforeRange = lineStart && Editor.range(editor, lineStart, at);
@@ -35,7 +35,7 @@ export const MatchesTriggerAndPattern = (
   // Point at the start of mention
   const mentionStart = match
     ? Editor.before(editor, at, {
-        unit: "character",
+        unit: 'character',
         distance: match[1].length + trigger.length,
       })
     : null;
@@ -53,7 +53,7 @@ export const useMention = (
   mentionables: MentionNodeData[] = [],
   {
     maxSuggestions = 10,
-    trigger = "@",
+    trigger = '@',
     mentionableFilter = (search: string) => (c: MentionNodeData) =>
       c.value.toLowerCase().includes(search.toLowerCase()),
     mentionableSearchPattern,
@@ -62,7 +62,7 @@ export const useMention = (
 ) => {
   const [targetRange, setTargetRange] = useState<Range | null>(null);
   const [valueIndex, setValueIndex] = useState(0);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState('');
   const values = mentionables
     .filter(mentionableFilter(search))
     .slice(0, maxSuggestions);
@@ -81,20 +81,20 @@ export const useMention = (
   const onKeyDownMention = useCallback(
     (e: any, editor: Editor) => {
       if (targetRange) {
-        if (e.key === "ArrowDown") {
+        if (e.key === 'ArrowDown') {
           e.preventDefault();
           return setValueIndex(getNextIndex(valueIndex, values.length - 1));
         }
-        if (e.key === "ArrowUp") {
+        if (e.key === 'ArrowUp') {
           e.preventDefault();
           return setValueIndex(getPreviousIndex(valueIndex, values.length - 1));
         }
-        if (e.key === "Escape") {
+        if (e.key === 'Escape') {
           e.preventDefault();
           return setTargetRange(null);
         }
 
-        if (["Tab", "Enter"].includes(e.key)) {
+        if (['Tab', 'Enter'].includes(e.key)) {
           e.preventDefault();
           onAddMention(editor, values[valueIndex]);
           return false;
@@ -119,7 +119,7 @@ export const useMention = (
         const cursor = Range.start(selection);
 
         const { range, match: beforeMatch } = mentionableSearchPattern
-          ? //new behavior, searches for matching string against pattern right after the trigger
+          ? // new behavior, searches for matching string against pattern right after the trigger
             MatchesTriggerAndPattern(editor, {
               at: cursor,
               trigger,

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -1,22 +1,22 @@
-import { useCallback, useState } from 'react';
-import { Editor, Point, Range, Transforms } from 'slate';
-import { escapeRegExp } from '../../common';
+import { useCallback, useState } from "react";
+import { Editor, Point, Range, Transforms } from "slate";
+import { escapeRegExp } from "../../common";
 import {
   getText,
   isPointAtWordEnd,
   isWordAfterTrigger,
-} from '../../common/queries';
-import { isCollapsed } from '../../common/queries/isCollapsed';
-import { insertMention } from './transforms';
-import { MentionNodeData, UseMentionOptions } from './types';
-import { getNextIndex, getPreviousIndex } from './utils';
+} from "../../common/queries";
+import { isCollapsed } from "../../common/queries/isCollapsed";
+import { insertMention } from "./transforms";
+import { MentionNodeData, UseMentionOptions } from "./types";
+import { getNextIndex, getPreviousIndex } from "./utils";
 
-export const MatchesTriggerAndPattern = (
+export const matchesTriggerAndPattern = (
   editor: Editor,
   { at, trigger, pattern }: { at: Point; trigger: string; pattern: string }
 ) => {
   // Point at the start of line
-  const lineStart = Editor.before(editor, at, { unit: 'line' });
+  const lineStart = Editor.before(editor, at, { unit: "line" });
 
   // Range from before to start
   const beforeRange = lineStart && Editor.range(editor, lineStart, at);
@@ -35,7 +35,7 @@ export const MatchesTriggerAndPattern = (
   // Point at the start of mention
   const mentionStart = match
     ? Editor.before(editor, at, {
-        unit: 'character',
+        unit: "character",
         distance: match[1].length + trigger.length,
       })
     : null;
@@ -53,7 +53,7 @@ export const useMention = (
   mentionables: MentionNodeData[] = [],
   {
     maxSuggestions = 10,
-    trigger = '@',
+    trigger = "@",
     mentionableFilter = (search: string) => (c: MentionNodeData) =>
       c.value.toLowerCase().includes(search.toLowerCase()),
     mentionableSearchPattern,
@@ -62,7 +62,7 @@ export const useMention = (
 ) => {
   const [targetRange, setTargetRange] = useState<Range | null>(null);
   const [valueIndex, setValueIndex] = useState(0);
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState("");
   const values = mentionables
     .filter(mentionableFilter(search))
     .slice(0, maxSuggestions);
@@ -81,20 +81,20 @@ export const useMention = (
   const onKeyDownMention = useCallback(
     (e: any, editor: Editor) => {
       if (targetRange) {
-        if (e.key === 'ArrowDown') {
+        if (e.key === "ArrowDown") {
           e.preventDefault();
           return setValueIndex(getNextIndex(valueIndex, values.length - 1));
         }
-        if (e.key === 'ArrowUp') {
+        if (e.key === "ArrowUp") {
           e.preventDefault();
           return setValueIndex(getPreviousIndex(valueIndex, values.length - 1));
         }
-        if (e.key === 'Escape') {
+        if (e.key === "Escape") {
           e.preventDefault();
           return setTargetRange(null);
         }
 
-        if (['Tab', 'Enter'].includes(e.key)) {
+        if (["Tab", "Enter"].includes(e.key)) {
           e.preventDefault();
           onAddMention(editor, values[valueIndex]);
           return false;
@@ -120,7 +120,7 @@ export const useMention = (
 
         const { range, match: beforeMatch } = mentionableSearchPattern
           ? // new behavior, searches for matching string against pattern right after the trigger
-            MatchesTriggerAndPattern(editor, {
+            matchesTriggerAndPattern(editor, {
               at: cursor,
               trigger,
               pattern: mentionableSearchPattern,

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -1,22 +1,22 @@
-import { useCallback, useState } from "react";
-import { Editor, Point, Range, Transforms } from "slate";
-import { escapeRegExp } from "../../common";
+import { useCallback, useState } from 'react';
+import { Editor, Point, Range, Transforms } from 'slate';
+import { escapeRegExp } from '../../common';
 import {
   getText,
   isPointAtWordEnd,
   isWordAfterTrigger,
-} from "../../common/queries";
-import { isCollapsed } from "../../common/queries/isCollapsed";
-import { insertMention } from "./transforms";
-import { MentionNodeData, UseMentionOptions } from "./types";
-import { getNextIndex, getPreviousIndex } from "./utils";
+} from '../../common/queries';
+import { isCollapsed } from '../../common/queries/isCollapsed';
+import { insertMention } from './transforms';
+import { MentionNodeData, UseMentionOptions } from './types';
+import { getNextIndex, getPreviousIndex } from './utils';
 
 export const matchesTriggerAndPattern = (
   editor: Editor,
   { at, trigger, pattern }: { at: Point; trigger: string; pattern: string }
 ) => {
   // Point at the start of line
-  const lineStart = Editor.before(editor, at, { unit: "line" });
+  const lineStart = Editor.before(editor, at, { unit: 'line' });
 
   // Range from before to start
   const beforeRange = lineStart && Editor.range(editor, lineStart, at);
@@ -35,7 +35,7 @@ export const matchesTriggerAndPattern = (
   // Point at the start of mention
   const mentionStart = match
     ? Editor.before(editor, at, {
-        unit: "character",
+        unit: 'character',
         distance: match[1].length + trigger.length,
       })
     : null;
@@ -53,7 +53,7 @@ export const useMention = (
   mentionables: MentionNodeData[] = [],
   {
     maxSuggestions = 10,
-    trigger = "@",
+    trigger = '@',
     mentionableFilter = (search: string) => (c: MentionNodeData) =>
       c.value.toLowerCase().includes(search.toLowerCase()),
     mentionableSearchPattern,
@@ -62,7 +62,7 @@ export const useMention = (
 ) => {
   const [targetRange, setTargetRange] = useState<Range | null>(null);
   const [valueIndex, setValueIndex] = useState(0);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState('');
   const values = mentionables
     .filter(mentionableFilter(search))
     .slice(0, maxSuggestions);
@@ -81,20 +81,20 @@ export const useMention = (
   const onKeyDownMention = useCallback(
     (e: any, editor: Editor) => {
       if (targetRange) {
-        if (e.key === "ArrowDown") {
+        if (e.key === 'ArrowDown') {
           e.preventDefault();
           return setValueIndex(getNextIndex(valueIndex, values.length - 1));
         }
-        if (e.key === "ArrowUp") {
+        if (e.key === 'ArrowUp') {
           e.preventDefault();
           return setValueIndex(getPreviousIndex(valueIndex, values.length - 1));
         }
-        if (e.key === "Escape") {
+        if (e.key === 'Escape') {
           e.preventDefault();
           return setTargetRange(null);
         }
 
-        if (["Tab", "Enter"].includes(e.key)) {
+        if (['Tab', 'Enter'].includes(e.key)) {
           e.preventDefault();
           onAddMention(editor, values[valueIndex]);
           return false;

--- a/stories/elements/mention.stories.tsx
+++ b/stories/elements/mention.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { text } from "@storybook/addon-knobs";
+import { text, boolean } from "@storybook/addon-knobs";
 import {
   EditablePlugins,
   HeadingPlugin,
@@ -58,6 +58,7 @@ export const Example = () => {
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueMentions);
+    console.log(value);
 
     const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
 
@@ -75,6 +76,12 @@ export const Example = () => {
       mentionableFilter: (search: string) => (mentionable: MentionNodeData) =>
         mentionable.email.toLowerCase().includes(search.toLowerCase()) ||
         mentionable.name.toLowerCase().includes(search.toLowerCase()),
+      mentionableSearchPattern: boolean(
+        "useCustomMentionableSearchPattern",
+        true
+      )
+        ? text("mentionableSearchPattern", "\\S*")
+        : undefined,
     });
 
     return (

--- a/stories/elements/mention.stories.tsx
+++ b/stories/elements/mention.stories.tsx
@@ -58,7 +58,6 @@ export const Example = () => {
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueMentions);
-    console.log(value);
 
     const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
 


### PR DESCRIPTION
## Issue

https://github.com/udecode/slate-plugins/issues/469

## What I did

Changed the way we match the start of a mention, allowing to show all mentionables right after typing the trigger.
Allowed more versatility in chars allowed in mention search by setting a regex for valid mentionable searches.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->