### PR TITLE
Fix multi-pass normalization of withRemoveEmptyNodes

### DIFF
--- a/packages/slate-plugins/src/normalizers/withRemoveEmptyNodes.ts
+++ b/packages/slate-plugins/src/normalizers/withRemoveEmptyNodes.ts
@@ -20,6 +20,7 @@ export const withRemoveEmptyNodes = (options: { type: string | string[] }) => <
       Node.string(node) === ''
     ) {
       Transforms.removeNodes(editor, { at: path });
+      return;
     }
 
     normalizeNode([node, path]);


### PR DESCRIPTION

## Issue
Normalization is a multi-pass process in Slate. `withRemoveEmptyNodes` remove nodes, and therefore other normalization steps such as merging nodes are broken if we don't end the current normalization pass after. 

Refer to https://github.com/ianstormtaylor/slate/blob/master/docs/concepts/10-normalizing.md#multi-pass-normalizing

> When you do call `Editor.removeNodes`, you're actually changing the content of the node that is currently being normalized. So even though you're ending the current normalization pass, by making a change to the node you're kicking off a new normalization pass. This results in a sort of recursive normalizing.

## What I did
Added a `return` statement to end the current normalization pass


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->