### PR TITLE
missing export from code-block refactor

### DIFF
--- a/packages/slate-plugins/src/elements/code-block/index.ts
+++ b/packages/slate-plugins/src/elements/code-block/index.ts
@@ -3,6 +3,7 @@ export * from './CodeBlockPlugin';
 export * from './decorateCodeBlock';
 export * from './defaults';
 export * from './deserializeCodeBlock';
+export * from './onKeyDownCodeBlock';
 export * from './queries';
 export * from './renderElementCodeBlock';
 export * from './renderLeafCodeBlock';


### PR DESCRIPTION
## Issue

Missed an export of onKeyDownCodeBlock

## What I did

Added the export to the code-block index.ts

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.