### PR TITLE
Fix multi pass normalization for withNormalizeTypes and withTrailingNode

### DIFF
--- a/packages/slate-plugins/src/normalizers/withNormalizeTypes.ts
+++ b/packages/slate-plugins/src/normalizers/withNormalizeTypes.ts
@@ -38,12 +38,13 @@ export const withNormalizeTypes = ({ rules, onError }: WithNormalizeTypes) => <
 
   editor.normalizeNode = ([currentNode, currentPath]) => {
     if (!currentPath.length) {
-      rules.forEach(({ strictType, type, path }) => {
+      const endCurrentNormalizationPass = rules.some(({ strictType, type, path }) => {
         const node = getNode(editor, path);
 
         if (node) {
           if (strictType && node.type !== strictType) {
             Transforms.setNodes(editor, { type: strictType }, { at: path });
+            return true;
           }
         } else {
           try {
@@ -55,11 +56,18 @@ export const withNormalizeTypes = ({ rules, onError }: WithNormalizeTypes) => <
               },
               { at: path }
             );
+            return true;
           } catch (err) {
             onError?.(err);
           }
         }
+
+        return false;
       });
+
+      if (endCurrentNormalizationPass) {
+        return;
+      }
     }
 
     return normalizeNode([currentNode, currentPath]);

--- a/packages/slate-plugins/src/normalizers/withTrailingNode.ts
+++ b/packages/slate-plugins/src/normalizers/withTrailingNode.ts
@@ -38,6 +38,7 @@ export const withTrailingNode = ({
           },
           { at: Path.next(lastPath) }
         );
+        return;
       }
     }
 


### PR DESCRIPTION
Follow-up to #515 

## Issue
Fixes multi-pass normalization of `withNormalizeTypes` and `withTrailingNode` normalizers.


## What I did
Added return statements to kick-off a new normalization pass after a transform is applied. In Slate, all transforms kick off a new normalization pass, and therefore it's important to early return to end the current normalization pass after a transform is applied in `normalizeNode`. 

Refer to https://github.com/ianstormtaylor/slate/blob/master/docs/concepts/10-normalizing.md#multi-pass-normalizing for more details


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->