### PR TITLE
code-block, remove a fixme, add a comment

### DIFF
--- a/packages/slate-plugins/src/elements/code-block/onKeyDownCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/onKeyDownCodeBlock.ts
@@ -70,11 +70,9 @@ export const onKeyDownCodeBlock = (
 
     e.preventDefault();
     e.stopPropagation();
-    return;
   }
 
-  if (e.key === 'mod+enter') {
-    // FIXME: this already works, verify if we need to add something specific here
-    // exit code block, move cursor to block after current code-block
-  }
+  // Note: rather than handling mod+enter/mod+shift+enter here, we recommend
+  // using the exit-break plugin/ If not using exit-break, follow similar logic
+  // to exit-break to add behavior to exit the code-block
 };


### PR DESCRIPTION
## Issue

Addressed a fixme in code-block after the refactor

## What I did

For code-block, removed a fixme and replaced with a comment explaining mod+enter/mod+shift+enter behavior

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->