### PR TITLE
Fix split list item with mark

### DIFF
--- a/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/insertListItem.ts
@@ -71,6 +71,10 @@ export const insertListItem = (editor: Editor, options?: ListOptions) => {
           at: nextParagraphPath,
           to: nextListItemPath,
         });
+        Transforms.select(editor, nextListItemPath);
+        Transforms.collapse(editor, {
+          edge: 'start',
+        });
       });
     } else {
       /**


### PR DESCRIPTION
## Issue
#480


## What I did
Fix the issue by ensuring that selection will move to the beginning of nextListItem when split happens.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [ ] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->