### PR TITLE
fixes #431, allow typing over selected content in single table cell

### DIFF
--- a/packages/slate-plugins/src/elements/table/withTable.ts
+++ b/packages/slate-plugins/src/elements/table/withTable.ts
@@ -75,8 +75,16 @@ export const withTable = (options?: WithTableOptions) => <T extends Editor>(
 
   editor.insertText = (text) => {
     const { selection } = editor;
+    const [start] = Editor.nodes(editor, {
+      match: matchCells,
+      at: selection?.anchor.path,
+    });
+    const [end] = Editor.nodes(editor, {
+      match: matchCells,
+      at: selection?.focus.path,
+    });
     // Collapse selection if multiple cells are selected to avoid breaking the table
-    if (!isCollapsed(selection)) {
+    if (!isCollapsed(selection) && (start || end) && start?.[0] !== end?.[0]) {
       const [cell] = Editor.nodes(editor, { match: matchCells });
       if (cell) {
         Transforms.collapse(editor, { edge: 'end' });


### PR DESCRIPTION
## Issue

A noted in #431, when content is selected in a table cell and you attempt to type over that content, instead the selection is collapsed and content is added at the end.

## What I did

Check to see if the start and end of the selection are in the same cell. If so, replace the selected content when typing

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.