### PR TITLE
prevent insertCodeBlock from nesting code-block elements

### DIFF
--- a/packages/slate-plugins/src/elements/code-block/transforms/insertCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/transforms/insertCodeBlock.ts
@@ -1,4 +1,5 @@
-import { Editor, Transforms } from 'slate';
+import { Editor, Node, Transforms } from 'slate';
+import { someNode } from '../../../common';
 import { isExpanded } from '../../../common/queries/isExpanded';
 import { isSelectionAtBlockStart } from '../../../common/queries/isSelectionAtBlockStart';
 import { wrapNodes } from '../../../common/transforms/wrapNodes';
@@ -22,6 +23,17 @@ export const insertCodeBlock = (
     pluginsOptions,
     DEFAULTS_CODE_BLOCK
   );
+
+  const matchCodeElements = (node: Node) =>
+    node.type === code_block.type || node.type === code_line.type;
+
+  if (
+    someNode(editor, {
+      match: matchCodeElements,
+    })
+  ) {
+    return;
+  }
 
   if (!isSelectionAtBlockStart(editor)) {
     editor.insertBreak();

--- a/packages/slate-plugins/src/elements/code-block/transforms/insertCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/transforms/insertCodeBlock.ts
@@ -1,7 +1,7 @@
 import { Editor, Node, Transforms } from 'slate';
-import { someNode } from '../../../common';
 import { isExpanded } from '../../../common/queries/isExpanded';
 import { isSelectionAtBlockStart } from '../../../common/queries/isSelectionAtBlockStart';
+import { someNode } from '../../../common/queries/someNode';
 import { wrapNodes } from '../../../common/transforms/wrapNodes';
 import { InsertNodesOptions } from '../../../common/types/Transforms.types';
 import { setDefaults } from '../../../common/utils/setDefaults';


### PR DESCRIPTION
## Issue

`insertCodeBlock` was allowing the insertion of a code-block element inside an existing code-block element

## What I did

Check to see if the selection is already a code-block or code-line. If so, return false.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.