### PR TITLE
accidentally deleted invoking codeblock plugin in recent story update

### DIFF
--- a/stories/elements/basic-elements.stories.tsx
+++ b/stories/elements/basic-elements.stories.tsx
@@ -55,6 +55,7 @@ export const Example = () => {
   if (boolean('ParagraphPlugin', true)) plugins.push(ParagraphPlugin(options));
   if (boolean('BlockquotePlugin', true))
     plugins.push(BlockquotePlugin(options));
+  if (boolean('CodeBlockPlugin', true)) plugins.push(CodeBlockPlugin(options));
   if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin(options));
   if (boolean('ResetBlockTypePlugin', true))
     plugins.push(ResetBlockTypePlugin(optionsResetBlockTypes));


### PR DESCRIPTION
## Issue

I broke CodeBlock in the basic elements story in a recent commit

## What I did

Restored CodeBlock in basic elements story

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.

