### PR TITLE
Insert code block below paragraph

### DIFF
--- a/packages/slate-plugins/src/elements/code-block/components/ToolbarCodeBlock.tsx
+++ b/packages/slate-plugins/src/elements/code-block/components/ToolbarCodeBlock.tsx
@@ -5,7 +5,7 @@ import { setDefaults } from '../../../common/utils/setDefaults';
 import { ToolbarButtonProps } from '../../../components/ToolbarButton/ToolbarButton.types';
 import { ToolbarElement } from '../../../components/ToolbarElement/ToolbarElement';
 import { DEFAULTS_CODE_BLOCK } from '../defaults';
-import { insertCodeBlock } from '../transforms/insertCodeBlock';
+import { insertEmptyCodeBlock } from '../transforms/insertEmptyCodeBlock';
 import { CodeBlockOptions, CodeLineOptions } from '../types';
 
 export const ToolbarCodeBlock = ({
@@ -20,7 +20,7 @@ export const ToolbarCodeBlock = ({
     <ToolbarElement
       type={code_block.type}
       onMouseDown={getPreventDefaultHandler(
-        insertCodeBlock,
+        insertEmptyCodeBlock,
         editor,
         { select: true },
         options

--- a/packages/slate-plugins/src/elements/code-block/components/ToolbarCodeBlock.tsx
+++ b/packages/slate-plugins/src/elements/code-block/components/ToolbarCodeBlock.tsx
@@ -6,12 +6,18 @@ import { ToolbarButtonProps } from '../../../components/ToolbarButton/ToolbarBut
 import { ToolbarElement } from '../../../components/ToolbarElement/ToolbarElement';
 import { DEFAULTS_CODE_BLOCK } from '../defaults';
 import { insertEmptyCodeBlock } from '../transforms/insertEmptyCodeBlock';
-import { CodeBlockOptions, CodeLineOptions } from '../types';
+import {
+  CodeBlockInsertOptions,
+  CodeBlockOptions,
+  CodeLineOptions,
+} from '../types';
 
 export const ToolbarCodeBlock = ({
   options,
   ...props
-}: ToolbarButtonProps & { options: CodeBlockOptions & CodeLineOptions }) => {
+}: ToolbarButtonProps & {
+  options: CodeBlockOptions & CodeLineOptions & CodeBlockInsertOptions;
+}) => {
   const { code_block } = setDefaults(options, DEFAULTS_CODE_BLOCK);
 
   const editor = useSlate();

--- a/packages/slate-plugins/src/elements/code-block/defaults.ts
+++ b/packages/slate-plugins/src/elements/code-block/defaults.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ELEMENT } from '../../common';
 import { CodeBlockElement } from './components/CodeBlockElement';
 import { CodeLineElement } from './components/CodeLineElement';
 import {

--- a/packages/slate-plugins/src/elements/code-block/transforms/insertEmptyCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/transforms/insertEmptyCodeBlock.ts
@@ -1,0 +1,32 @@
+import { Editor, Path, Transforms } from 'slate';
+import { InsertNodesOptions, setDefaults } from '../../../common';
+import { DEFAULT_ELEMENT } from '../../../common/types/node.types';
+import { exitBreakAtEdges } from '../../../handlers';
+import { DEFAULTS_CODE_BLOCK } from '../defaults';
+import { CodeBlockOptions, CodeLineOptions } from '../types';
+import { insertCodeBlock } from './insertCodeBlock';
+
+/**
+ * Called by toolbars to make sure a code-block gets inserted below a paragraph
+ * rather than awkwardly splitting the current selection.
+ */
+export const insertEmptyCodeBlock = (
+  editor: Editor,
+  options: Omit<InsertNodesOptions, 'match'> = {},
+  pluginsOptions: CodeBlockOptions & CodeLineOptions = {},
+  defaultType: string = DEFAULT_ELEMENT,
+  level = 1
+) => {
+  if (!editor.selection) return;
+  const selectionPath = Editor.path(editor, editor.selection);
+  const insertPath = Path.next(selectionPath.slice(0, level + 1));
+  Transforms.insertNodes(
+    editor,
+    { type: defaultType, children: [{ text: '' }] },
+    {
+      at: insertPath,
+      select: true,
+    }
+  );
+  insertCodeBlock(editor, options, pluginsOptions);
+};

--- a/packages/slate-plugins/src/elements/code-block/transforms/insertEmptyCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/transforms/insertEmptyCodeBlock.ts
@@ -1,9 +1,15 @@
 import { Editor, Path, Transforms } from 'slate';
-import { InsertNodesOptions, setDefaults } from '../../../common';
+import {
+  InsertNodesOptions,
+  isBlockAboveEmpty,
+  isExpanded,
+} from '../../../common';
 import { DEFAULT_ELEMENT } from '../../../common/types/node.types';
-import { exitBreakAtEdges } from '../../../handlers';
-import { DEFAULTS_CODE_BLOCK } from '../defaults';
-import { CodeBlockOptions, CodeLineOptions } from '../types';
+import {
+  CodeBlockInsertOptions,
+  CodeBlockOptions,
+  CodeLineOptions,
+} from '../types';
 import { insertCodeBlock } from './insertCodeBlock';
 
 /**
@@ -13,20 +19,29 @@ import { insertCodeBlock } from './insertCodeBlock';
 export const insertEmptyCodeBlock = (
   editor: Editor,
   options: Omit<InsertNodesOptions, 'match'> = {},
-  pluginsOptions: CodeBlockOptions & CodeLineOptions = {},
-  defaultType: string = DEFAULT_ELEMENT,
-  level = 1
+  pluginsOptions: CodeBlockInsertOptions &
+    CodeBlockOptions &
+    CodeLineOptions = {
+    defaultType: DEFAULT_ELEMENT,
+    level: 1,
+  }
 ) => {
   if (!editor.selection) return;
-  const selectionPath = Editor.path(editor, editor.selection);
-  const insertPath = Path.next(selectionPath.slice(0, level + 1));
-  Transforms.insertNodes(
-    editor,
-    { type: defaultType, children: [{ text: '' }] },
-    {
-      at: insertPath,
-      select: true,
-    }
-  );
+
+  const defaultType = pluginsOptions.defaultType || DEFAULT_ELEMENT;
+  const level = pluginsOptions.level || 1;
+
+  if (isExpanded(editor.selection) || isBlockAboveEmpty(editor)) {
+    const selectionPath = Editor.path(editor, editor.selection);
+    const insertPath = Path.next(selectionPath.slice(0, level + 1));
+    Transforms.insertNodes(
+      editor,
+      { type: defaultType, children: [{ text: '' }] },
+      {
+        at: insertPath,
+        select: true,
+      }
+    );
+  }
   insertCodeBlock(editor, options, pluginsOptions);
 };

--- a/packages/slate-plugins/src/elements/code-block/types.ts
+++ b/packages/slate-plugins/src/elements/code-block/types.ts
@@ -115,6 +115,11 @@ export interface CodeBlockOptions extends CodeBlockPluginOptions<'type'> {}
 
 export interface CodeLineOptions extends CodeLinePluginOptions<'type'> {}
 
+export interface CodeBlockInsertOptions {
+  defaultType: string;
+  level: number;
+}
+
 export interface CodeBlockElementStyles {
   /**
    * Style for the root element.


### PR DESCRIPTION
## Issue

Inserting code_block elements from the toolbar mid-paragraph was a bit inconsistent.

![codeBlockInsert](https://user-images.githubusercontent.com/97291/110214759-505bfd00-7e63-11eb-884e-5f1010f7693d.gif)

* If some text was selected, it would fail silently
* If no text was selected but it was mid-sentence, it would take the rest of the content and inject it into the code block

In general we're trying to avoid taking content and converting it to code_block content, at least for now.

## What I did

* Added an `insertEmptyCodeBlock` transform to be called from the `ToolbarCodeBlock` `onmousedown` handler
* Added a couple of options, `defaultType` and `level` (these are not hooked into the normal `setDefaults` call, I could use guidance if there's a better way to do this)
* Check to see if the cursor either has an expanded selection, or a collapsed selection in the middle of an element. If so, insert a new block, select it, and then call `insertCodeBlock`
* If the selection is in an empty block element, replace that with a code block

## Checklist