### PR TITLE
missing export, minor cleanup of insertEmptyCodeBlock transform

### DIFF
--- a/packages/slate-plugins/src/elements/code-block/transforms/index.ts
+++ b/packages/slate-plugins/src/elements/code-block/transforms/index.ts
@@ -2,6 +2,7 @@ export * from './deleteStartSpace';
 export * from './indentCodeLine';
 export * from './insertCodeBlock';
 export * from './insertCodeLine';
+export * from './insertEmptyCodeBlock';
 export * from './outdentCodeLine';
 export * from './toggleCodeBlock';
 export * from './unwrapCodeBlock';

--- a/packages/slate-plugins/src/elements/code-block/transforms/insertEmptyCodeBlock.ts
+++ b/packages/slate-plugins/src/elements/code-block/transforms/insertEmptyCodeBlock.ts
@@ -31,7 +31,7 @@ export const insertEmptyCodeBlock = (
   const defaultType = pluginsOptions.defaultType || DEFAULT_ELEMENT;
   const level = pluginsOptions.level || 1;
 
-  if (isExpanded(editor.selection) || isBlockAboveEmpty(editor)) {
+  if (isExpanded(editor.selection) || !isBlockAboveEmpty(editor)) {
     const selectionPath = Editor.path(editor, editor.selection);
     const insertPath = Path.next(selectionPath.slice(0, level + 1));
     Transforms.insertNodes(


### PR DESCRIPTION
## Issue

Missed a dependency in #549
Inverted logic of selected block being empty

## What I did

Added missing dependency
Fixed the logic for checking if the block above the selection is empty

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.
