### PR TITLE
add mod+a handler to select all contents of a table

### DIFF
--- a/packages/slate-plugins/src/elements/table/onKeyDownTable.ts
+++ b/packages/slate-plugins/src/elements/table/onKeyDownTable.ts
@@ -1,7 +1,11 @@
 import { Editor, Transforms } from 'slate';
+import { setDefaults } from '../../common';
+import { getAbove } from '../../common/queries';
+import { DEFAULTS_LIST } from '../list';
 import { getNextTableCell } from './queries/getNextTableCell';
 import { getPreviousTableCell } from './queries/getPreviousTableCell';
 import { getTableCellEntry } from './queries/getTableCellEntry';
+import { DEFAULTS_TABLE } from './defaults';
 import { TableHotKey, TableOnKeyDownOptions } from './types';
 
 export const onKeyDownTable = (options?: TableOnKeyDownOptions) => (
@@ -41,5 +45,22 @@ export const onKeyDownTable = (options?: TableOnKeyDownOptions) => (
         Transforms.select(editor, nextCellPath);
       }
     }
+  }
+
+  // FIXME: would prefer this as mod+a, but doesn't work
+  if (e.key === 'a' && (e.metaKey || e.ctrlKey)) {
+    const { table } = setDefaults(options, DEFAULTS_TABLE);
+
+    const res = getAbove(editor, { match: { type: table.type } });
+    if (!res) return;
+
+    const tableElement = res;
+    const [, tablePath] = tableElement;
+
+    // select the whole table
+    Transforms.select(editor, tablePath);
+
+    e.preventDefault();
+    e.stopPropagation();
   }
 };

--- a/packages/slate-plugins/src/elements/table/onKeyDownTable.ts
+++ b/packages/slate-plugins/src/elements/table/onKeyDownTable.ts
@@ -1,7 +1,6 @@
 import { Editor, Transforms } from 'slate';
 import { setDefaults } from '../../common';
 import { getAbove } from '../../common/queries';
-import { DEFAULTS_LIST } from '../list';
 import { getNextTableCell } from './queries/getNextTableCell';
 import { getPreviousTableCell } from './queries/getPreviousTableCell';
 import { getTableCellEntry } from './queries/getTableCellEntry';
@@ -54,8 +53,7 @@ export const onKeyDownTable = (options?: TableOnKeyDownOptions) => (
     const res = getAbove(editor, { match: { type: table.type } });
     if (!res) return;
 
-    const tableElement = res;
-    const [, tablePath] = tableElement;
+    const [, tablePath] = res;
 
     // select the whole table
     Transforms.select(editor, tablePath);


### PR DESCRIPTION
## Issue

When focus is on a table, mod+a keyboard event was selecting the entire page rather than all contents of a table

refs #547 

## What I did

Added a keyboard handler in `onKeyDownTable` to select the entire table when pressed.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.