### PR TITLE
getListItemEntry should return list & listItemNode if the selection i…

### DIFF
--- a/packages/slate-plugins/src/elements/list/queries/getListItemEntry.spec.tsx
+++ b/packages/slate-plugins/src/elements/list/queries/getListItemEntry.spec.tsx
@@ -48,6 +48,121 @@ describe('when the cursor is in a list item paragraph', () => {
   });
 });
 
+describe('when the cursor is in a nested list item paragraph', () => {
+  const input = ((
+    <editor>
+      <hul>
+        <hli>
+          <hp>1</hp>
+          <hul>
+            <hli>
+              <hp>
+                2
+                <cursor />
+              </hp>
+            </hli>
+          </hul>
+        </hli>
+      </hul>
+    </editor>
+  ) as any) as Editor;
+
+  const listNode = (
+    <hul>
+      <hli>
+        <hp>
+          2
+          <cursor />
+        </hp>
+      </hli>
+    </hul>
+  ) as any;
+
+  const listItemNode = (
+    <hli>
+      <hp>
+        2
+        <cursor />
+      </hp>
+    </hli>
+  ) as any;
+
+  it('should be', () => {
+    const res = getListItemEntry(input);
+
+    expect(res).toEqual({
+      list: [listNode, [0, 0, 1]],
+      listItem: [listItemNode, [0, 0, 1, 0]],
+    });
+  });
+});
+
+describe('when the selection range includes root list item', () => {
+  const input = ((
+    <editor>
+      <hul>
+        <hli>
+          <hp>
+            aa
+            <focus />
+            aa
+          </hp>
+          <hul>
+            <hli>
+              <hp>
+                bb
+                <anchor />
+                bb
+              </hp>
+            </hli>
+          </hul>
+        </hli>
+      </hul>
+    </editor>
+  ) as any) as Editor;
+
+  const listNode = (
+    <hul>
+      <hli>
+        <hp>aaaa</hp>
+        <hul>
+          <hli>
+            <hp>bbbb</hp>
+          </hli>
+        </hul>
+      </hli>
+    </hul>
+  ) as any;
+
+  const listItemNode = (
+    <hli>
+      <hp>
+        aa
+        <focus />
+        aa
+      </hp>
+      <hul>
+        <hli>
+          <hp>
+            bb
+            <anchor />
+            bb
+          </hp>
+        </hli>
+      </hul>
+    </hli>
+  ) as any;
+
+  it('should be', () => {
+    const res = getListItemEntry(input);
+
+    expect(res).toEqual({
+      list: [listNode, [0]],
+      listItem: [listItemNode, [0, 0]],
+    });
+  });
+});
+
 describe('when the cursor is not in a list item', () => {
   const input = ((
     <editor>

--- a/packages/slate-plugins/src/elements/list/queries/getListItemEntry.ts
+++ b/packages/slate-plugins/src/elements/list/queries/getListItemEntry.ts
@@ -1,4 +1,5 @@
-import { Editor, Location } from 'slate';
+import { Editor, Location, Range } from 'slate';
+import { isCollapsed } from '../../../common';
 import { getAbove } from '../../../common/queries/getAbove';
 import { getParent } from '../../../common/queries/getParent';
 import { someNode } from '../../../common/queries/someNode';
@@ -20,6 +21,11 @@ export const getListItemEntry = (
     const selectionParent = getParent(editor, at);
     if (!selectionParent) return;
     const [, paragraphPath] = selectionParent;
+
+    // If selection range includes root list item
+    if (Range.isRange(at) && !isCollapsed(at) && paragraphPath.length === 1) {
+      at = at.focus.path;
+    }
 
     const listItem =
       getAbove(editor, { at, match: { type: li.type } }) ||


### PR DESCRIPTION
…s a range including the root list item.

## Issue
#### Given below input
```<editor>
      <hul>
        <hli>
          <hp>
            aa
            <focus />
            aa
          </hp>
          <hul>
            <hli>
              <hp>
                bb
                <anchor />
                bb
              </hp>
            </hli>
          </hul>
        </hli>
      </hul>
    </editor>
```
#### When `getListItemEntry` is called with above input
#### Then it returns undefined

## What I did

Detecting if the selection includes root list item (path's length === 1) and then overwriting the `at` to be the range's focus path. In the result the `getListItemEntry` returns correct `listNode` and `listItemNode`

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->