### PR TITLE
Updated useMentionPlugin return data

### DIFF
--- a/packages/elements/mention-ui/src/MentionSelect/MentionSelect.spec.tsx
+++ b/packages/elements/mention-ui/src/MentionSelect/MentionSelect.spec.tsx
@@ -20,6 +20,7 @@ describe('when MentionSelect', () => {
           options={mentionables}
           valueIndex={0}
           onClickMention={() => {}}
+          searchValue=""
         />
       );
 
@@ -61,6 +62,7 @@ describe('when MentionSelect', () => {
           at={editor.selection}
           options={mentionables}
           valueIndex={0}
+          searchValue=""
           onClickMention={() => {}}
         />
       );

--- a/packages/elements/mention/src/types.ts
+++ b/packages/elements/mention/src/types.ts
@@ -47,4 +47,6 @@ export interface GetMentionSelectProps {
    * Callback called when clicking on a mention option
    */
   onClickMention?: (editor: SPEditor, option: MentionNodeData) => void;
+
+  searchValue: string;
 }

--- a/packages/elements/mention/src/useMentionPlugin.ts
+++ b/packages/elements/mention/src/useMentionPlugin.ts
@@ -41,6 +41,7 @@ export const useMentionPlugin = ({
 }: MentionPluginOptions = {}): {
   plugin: SlatePlugin;
   getMentionSelectProps: () => GetMentionSelectProps;
+  searchValue: string;
 } => {
   const [targetRange, setTargetRange] = useState<Range | null>(null);
   const [valueIndex, setValueIndex] = useState(0);
@@ -148,8 +149,10 @@ export const useMentionPlugin = ({
         valueIndex,
         options: values,
         onClickMention: onAddMention,
+        searchValue: search,
       }),
-      [onAddMention, targetRange, valueIndex, values]
+      [onAddMention, search, targetRange, valueIndex, values]
     ),
+    searchValue: search,
   };
 };


### PR DESCRIPTION
Added searchValue in useMentionPlugin as before

## Issue
Search value is not returned in the useMentionPlugin function I was having issues while I refactor the code to the new version. 


## What I did
Added searchValue in the useMentionPlugin return data


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->