### PR TITLE
Fix table delete content

### DIFF
--- a/packages/elements/table/src/withTable.ts
+++ b/packages/elements/table/src/withTable.ts
@@ -70,7 +70,7 @@ export const withTable = (): WithOverride<SPEditor> => (editor) => {
         match: matchCells,
       });
       for (const [, path] of cells) {
-        for (const [, childPath] of Node.children(editor, path)) {
+        for (const [, childPath] of Node.children(editor, path, { reverse: true })) {
           Transforms.removeNodes(editor, { at: childPath });
         }
       }


### PR DESCRIPTION
## Issue
Select table cells with mouse, delete, crash.


## What I did
Delete cell content with reversed order.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->