### PR TITLE
Disable code-block syntax highlighting until we resolve formatting issues

### DIFF
--- a/packages/elements/code-block/src/getCodeBlockDecorate.ts
+++ b/packages/elements/code-block/src/getCodeBlockDecorate.ts
@@ -62,28 +62,28 @@ export const getCodeBlockDecorate = (): Decorate => (editor) => {
     if (isElement(node) && node.type === code_block.type) {
       const text = Node.string(node);
       // const langName: any = parent.lang || 'markup';
-      const langName: any = 'javascript';
+      const langName: any = '';
       const lang = languages[langName];
 
-      // if (lang) {
-      const tokens = tokenize(text, lang);
-      let offset = 0;
+      if (lang) {
+        const tokens = tokenize(text, lang);
+        let offset = 0;
 
-      for (const element of tokens) {
-        if (typeof element === 'string') {
-          offset += element.length;
-        } else {
-          const token: Token = element;
-          ranges.push({
-            anchor: { path, offset },
-            focus: { path, offset: offset + token.length },
-            className: `prism-token token ${token.type} `,
-            prism: true,
-          });
-          offset += token.length;
+        for (const element of tokens) {
+          if (typeof element === 'string') {
+            offset += element.length;
+          } else {
+            const token: Token = element;
+            ranges.push({
+              anchor: { path, offset },
+              focus: { path, offset: offset + token.length },
+              className: `prism-token token ${token.type} `,
+              prism: true,
+            });
+            offset += token.length;
+          }
         }
       }
-      // }
     }
     return ranges;
   };


### PR DESCRIPTION
## Issue

Code-block syntax highlighting is not working accurately (randomly highlighting keywords breaking the formatting. Also without a user mechanism to specify the language, having a default of JavaScript isn't ideal for many users.

## What I did

Set the language to empty for now, and skip the application of syntax highlighting until we have time to investigate this further.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->