### PR TITLE
autoformat improvements and isType common query

### DIFF
--- a/packages/autoformat/src/__tests__/withAutoformat/block/code-block-middle.spec.tsx
+++ b/packages/autoformat/src/__tests__/withAutoformat/block/code-block-middle.spec.tsx
@@ -19,8 +19,9 @@ const input = (
 
 const output = (
   <editor>
+    <hp>hello</hp>
     <hcodeblock>
-      <hcodeline>hello</hcodeline>
+      <hcodeline>new</hcodeline>
     </hcodeblock>
   </editor>
 ) as any;
@@ -29,6 +30,7 @@ it('should autoformat', () => {
   const editor = withAutoformat(optionsAutoformat)(withReact(input));
 
   editor.insertText('`');
+  editor.insertText('new');
 
   expect(input.children).toEqual(output.children);
 });

--- a/packages/autoformat/src/__tests__/withAutoformat/inline/code-block.spec.tsx
+++ b/packages/autoformat/src/__tests__/withAutoformat/inline/code-block.spec.tsx
@@ -19,9 +19,9 @@ const input = (
 
 const output = (
   <editor>
-    <hp>hello</hp>
+    <hp>helloworld</hp>
     <hcodeblock>
-      <hcodeline>world</hcodeline>
+      <hcodeline>new</hcodeline>
     </hcodeblock>
   </editor>
 ) as any;
@@ -30,6 +30,7 @@ it('should autoformat', () => {
   const editor = withAutoformat(optionsAutoformat)(withReact(input));
 
   editor.insertText('`');
+  editor.insertText('new');
 
   expect(input.children).toEqual(output.children);
 });

--- a/packages/common/src/queries/index.ts
+++ b/packages/common/src/queries/index.ts
@@ -38,6 +38,7 @@ export * from './isSelectionAtBlockStart';
 export * from './isSelectionExpanded';
 export * from './isStart';
 export * from './isTextByPath';
+export * from './isType';
 export * from './isWordAfterTrigger';
 export * from './match';
 export * from './queryEditor';

--- a/packages/common/src/queries/isType.ts
+++ b/packages/common/src/queries/isType.ts
@@ -1,8 +1,4 @@
-import {
-  getSlatePluginType,
-  SlatePluginKey,
-  SPEditor,
-} from '@udecode/slate-plugins-core';
+import { getSlatePluginType, SPEditor } from '@udecode/slate-plugins-core';
 import castArray from 'lodash/castArray';
 /**
  * Does the node match the type provided.
@@ -11,7 +7,7 @@ import castArray from 'lodash/castArray';
 export const isType = (
   editor: SPEditor,
   node: any,
-  pluginKey?: SlatePluginKey | SlatePluginKey[]
+  pluginKey?: string | string[]
 ) => {
   const keys = castArray(pluginKey);
   keys.forEach((key) => {

--- a/packages/common/src/queries/isType.ts
+++ b/packages/common/src/queries/isType.ts
@@ -1,0 +1,17 @@
+import {
+  getSlatePluginType,
+  SlatePluginKey,
+  SPEditor,
+} from '@udecode/slate-plugins-core';
+
+/**
+ * Does the node match the type provided.
+ */
+
+export const isType = (
+  editor: SPEditor,
+  node: any,
+  pluginKey?: SlatePluginKey
+) => {
+  return node?.type === getSlatePluginType(editor, pluginKey);
+};

--- a/packages/common/src/queries/isType.ts
+++ b/packages/common/src/queries/isType.ts
@@ -3,7 +3,7 @@ import {
   SlatePluginKey,
   SPEditor,
 } from '@udecode/slate-plugins-core';
-
+import castArray from 'lodash/castArray';
 /**
  * Does the node match the type provided.
  */
@@ -11,7 +11,11 @@ import {
 export const isType = (
   editor: SPEditor,
   node: any,
-  pluginKey?: SlatePluginKey
+  pluginKey?: SlatePluginKey | SlatePluginKey[]
 ) => {
-  return node?.type === getSlatePluginType(editor, pluginKey);
+  const keys = castArray(pluginKey);
+  keys.forEach((key) => {
+    if (node?.type === getSlatePluginType(editor, key)) return true;
+  });
+  return false;
 };

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -75,10 +75,12 @@ export const optionsAutoformat: WithAutoformatOptions = {
           const [node] = parentEntry;
           if (
             isElement(node) &&
-            !isType(editor, node, ELEMENT_CODE_BLOCK) &&
-            !isType(editor, node, ELEMENT_CODE_LINE)
+            !isType((editor as any) as SPEditor, node, ELEMENT_CODE_BLOCK) &&
+            !isType((editor as any) as SPEditor, node, ELEMENT_CODE_LINE)
           ) {
-            toggleList(editor as SPEditor, { type: options[ELEMENT_UL].type });
+            toggleList((editor as any) as SPEditor, {
+              type: options[ELEMENT_UL].type,
+            });
           }
         }
       },
@@ -94,10 +96,12 @@ export const optionsAutoformat: WithAutoformatOptions = {
           const [node] = parentEntry;
           if (
             isElement(node) &&
-            !isType(editor, node, ELEMENT_CODE_BLOCK) &&
-            !isType(editor, node, ELEMENT_CODE_LINE)
+            !isType((editor as any) as SPEditor, node, ELEMENT_CODE_BLOCK) &&
+            !isType((editor as any) as SPEditor, node, ELEMENT_CODE_LINE)
           ) {
-            toggleList(editor as SPEditor, { type: options[ELEMENT_OL].type });
+            toggleList((editor as any) as SPEditor, {
+              type: options[ELEMENT_OL].type,
+            });
           }
         }
       },
@@ -154,7 +158,7 @@ export const optionsAutoformat: WithAutoformatOptions = {
       triggerAtBlockStart: false,
       preFormat,
       format: (editor) => {
-        insertEmptyCodeBlock(editor as SPEditor, {
+        insertEmptyCodeBlock((editor as any) as SPEditor, {
           defaultType: ELEMENT_DEFAULT,
           insertNodesOptions: { select: true },
         });

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -15,6 +15,7 @@ import {
   ELEMENT_UL,
   getParent,
   insertEmptyCodeBlock,
+  isElement,
   isType,
   MARK_BOLD,
   MARK_CODE,
@@ -69,8 +70,11 @@ export const optionsAutoformat: WithAutoformatOptions = {
       preFormat,
       format: (editor) => {
         if (editor.selection) {
-          const [node] = getParent(editor, editor.selection);
+          const parentEntry = getParent(editor, editor.selection);
+          if (!parentEntry) return;
+          const [node] = parentEntry;
           if (
+            isElement(node) &&
             !isType(editor, node, ELEMENT_CODE_BLOCK) &&
             !isType(editor, node, ELEMENT_CODE_LINE)
           ) {
@@ -85,8 +89,11 @@ export const optionsAutoformat: WithAutoformatOptions = {
       preFormat,
       format: (editor) => {
         if (editor.selection) {
-          const [node] = getParent(editor, editor.selection);
+          const parentEntry = getParent(editor, editor.selection);
+          if (!parentEntry) return;
+          const [node] = parentEntry;
           if (
+            isElement(node) &&
             !isType(editor, node, ELEMENT_CODE_BLOCK) &&
             !isType(editor, node, ELEMENT_CODE_LINE)
           ) {

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -2,6 +2,7 @@ import {
   ELEMENT_BLOCKQUOTE,
   ELEMENT_CODE_BLOCK,
   ELEMENT_CODE_LINE,
+  ELEMENT_DEFAULT,
   ELEMENT_H1,
   ELEMENT_H2,
   ELEMENT_H3,
@@ -147,6 +148,7 @@ export const optionsAutoformat: WithAutoformatOptions = {
       preFormat,
       format: (editor) => {
         insertEmptyCodeBlock(editor as SPEditor, {
+          defaultType: ELEMENT_DEFAULT,
           insertNodesOptions: { select: true },
         });
       },

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -1,6 +1,7 @@
 import {
   ELEMENT_BLOCKQUOTE,
   ELEMENT_CODE_BLOCK,
+  ELEMENT_CODE_LINE,
   ELEMENT_H1,
   ELEMENT_H2,
   ELEMENT_H3,
@@ -11,7 +12,9 @@ import {
   ELEMENT_OL,
   ELEMENT_TODO_LI,
   ELEMENT_UL,
-  insertCodeBlock,
+  getParent,
+  insertEmptyCodeBlock,
+  isType,
   MARK_BOLD,
   MARK_CODE,
   MARK_ITALIC,
@@ -64,7 +67,15 @@ export const optionsAutoformat: WithAutoformatOptions = {
       markup: ['*', '-'],
       preFormat,
       format: (editor) => {
-        toggleList(editor as SPEditor, { type: options[ELEMENT_UL].type });
+        if (editor.selection) {
+          const [node] = getParent(editor, editor.selection);
+          if (
+            !isType(editor, node, ELEMENT_CODE_BLOCK) &&
+            !isType(editor, node, ELEMENT_CODE_LINE)
+          ) {
+            toggleList(editor as SPEditor, { type: options[ELEMENT_UL].type });
+          }
+        }
       },
     },
     {
@@ -72,7 +83,15 @@ export const optionsAutoformat: WithAutoformatOptions = {
       markup: ['1.', '1)'],
       preFormat,
       format: (editor) => {
-        toggleList(editor as SPEditor, { type: options[ELEMENT_OL].type });
+        if (editor.selection) {
+          const [node] = getParent(editor, editor.selection);
+          if (
+            !isType(editor, node, ELEMENT_CODE_BLOCK) &&
+            !isType(editor, node, ELEMENT_CODE_LINE)
+          ) {
+            toggleList(editor as SPEditor, { type: options[ELEMENT_OL].type });
+          }
+        }
       },
     },
     {
@@ -127,7 +146,9 @@ export const optionsAutoformat: WithAutoformatOptions = {
       triggerAtBlockStart: false,
       preFormat,
       format: (editor) => {
-        insertCodeBlock(editor as SPEditor, { select: true });
+        insertEmptyCodeBlock(editor as SPEditor, {
+          insertNodesOptions: { select: true },
+        });
       },
     },
   ],


### PR DESCRIPTION
## Issue

I often want a quick way to determine if something is of a particular type which may include a custom ast type.

For autoformat, we currently have a few extensions to prevent lists from getting inserted into code-block elements and to insert an empty code_block element.

## What I did

* Added isType (my type definition for node is currently an any, could use guidance on what this should be)
* Updated shared autoformatRules from stories

## Checklist

- [x] The new code matches the existing patterns and styles.
- [ ] The stories still work (run `yarn storybook`). (this is failing as it's failing to recognize getParent and isType for my import statements, will resolve this asap)
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.
