### PR TITLE
Mention plugin was prematurely clearing targetRange with keyboard events

### DIFF
--- a/packages/elements/mention/src/__tests__/useMention/onKeyDown/key/enter.spec.tsx
+++ b/packages/elements/mention/src/__tests__/useMention/onKeyDown/key/enter.spec.tsx
@@ -49,5 +49,8 @@ it('should go down', () => {
   });
 
   expect(editor.children).toEqual(output.children);
+  act(() => {
+    result.current.plugin.onChange?.(editor)([]);
+  });
   expect(result.current.getMentionSelectProps().at).toEqual(null);
 });

--- a/packages/elements/mention/src/useMentionPlugin.ts
+++ b/packages/elements/mention/src/useMentionPlugin.ts
@@ -58,7 +58,6 @@ export const useMentionPlugin = ({
       if (targetRange !== null) {
         Transforms.select(editor, targetRange);
         insertMention(editor, { data, insertSpaceAfterMention, pluginKey });
-        return setTargetRange(null);
       }
     },
     [targetRange, insertSpaceAfterMention, pluginKey]


### PR DESCRIPTION
## Issue

When using the keyboard to select an item in the mention plugin, the selection was failing as the targetRange was getting cleared before the selection could occur. It is unclear how this is not an error in the CodeSandbox example (perhaps that environment has different behavior with respect to how events get fired).

## What I did

Removed a call to clear the range (it gets cleared after the node gets inserted anyway).

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.