### PR TITLE
Allow custom typing for editor in plugin, defaulting to SPEditor

### DIFF
--- a/packages/core/src/types/SlatePlugin/Decorate.ts
+++ b/packages/core/src/types/SlatePlugin/Decorate.ts
@@ -6,6 +6,6 @@ import { SPEditor } from '../SPEditor';
  * If the function returns undefined then no ranges are modified.
  * If the function returns an array the returned ranges are merged with the ranges called by other plugins.
  */
-export type Decorate = (
-  editor: SPEditor
+export type Decorate<T extends SPEditor = SPEditor> = (
+  editor: T
 ) => (entry: NodeEntry) => Range[] | undefined;

--- a/packages/core/src/types/SlatePlugin/Deserialize.ts
+++ b/packages/core/src/types/SlatePlugin/Deserialize.ts
@@ -15,8 +15,8 @@ export type DeserializeNode = {
 /**
  * HTML Deserializer for element and leaf.
  */
-export type Deserialize = (
-  editor: SPEditor
+export type Deserialize<T extends SPEditor = SPEditor> = (
+  editor: T
 ) => {
   element?: DeserializeNode[];
   leaf?: DeserializeNode[];

--- a/packages/core/src/types/SlatePlugin/OnChange.ts
+++ b/packages/core/src/types/SlatePlugin/OnChange.ts
@@ -6,4 +6,4 @@ import { TNode } from '../TNode';
  * To prevent the next handler from running, return false.
  * @see {@link SlatePropsOnChange}
  */
-export type OnChange = (editor: SPEditor) => (value: TNode[]) => boolean | void;
+export type OnChange<T extends SPEditor = SPEditor> = (editor: T) => (value: TNode[]) => boolean | void;

--- a/packages/core/src/types/SlatePlugin/OnDOMBeforeInput.ts
+++ b/packages/core/src/types/SlatePlugin/OnDOMBeforeInput.ts
@@ -6,6 +6,6 @@ import { SPEditor } from '../SPEditor';
  * to true.
  * To prevent the next handler from running return false.
  */
-export type OnDOMBeforeInput = (
-  editor: SPEditor
+export type OnDOMBeforeInput<T extends SPEditor = SPEditor> = (
+  editor: T
 ) => (event: Event) => boolean | undefined | void;

--- a/packages/core/src/types/SlatePlugin/OnKeyDown.ts
+++ b/packages/core/src/types/SlatePlugin/OnKeyDown.ts
@@ -4,4 +4,4 @@ import { SPEditor } from '../SPEditor';
  * Function called on key down event.
  * To prevent the next handler from running, return false.
  */
-export type OnKeyDown = (editor: SPEditor) => (e: any) => boolean | void;
+export type OnKeyDown<T extends SPEditor = SPEditor> = (editor: T) => (e: any) => boolean | void;

--- a/packages/core/src/types/SlatePlugin/RenderElement.ts
+++ b/packages/core/src/types/SlatePlugin/RenderElement.ts
@@ -6,6 +6,6 @@ import { TRenderElementProps } from '../TRenderElementProps';
  * If the function returns undefined then the next RenderElement function is called.
  * If the function renders a JSX element then that JSX element is rendered.
  */
-export type RenderElement = (
-  editor: SPEditor
+export type RenderElement<T extends SPEditor = SPEditor> = (
+  editor: T
 ) => (props: TRenderElementProps) => JSX.Element | undefined;

--- a/packages/core/src/types/SlatePlugin/RenderLeaf.ts
+++ b/packages/core/src/types/SlatePlugin/RenderLeaf.ts
@@ -10,6 +10,6 @@ import { TRenderLeafProps } from '../TRenderLeafProps';
  * The attributes are added by default.
  * RenderLeaf always returns a JSX element (even if unmodified) to support multiple marks on a node.
  */
-export type RenderLeaf = (
-  editor: SPEditor
+export type RenderLeaf<T extends SPEditor = SPEditor> = (
+  editor: T
 ) => (props: TRenderLeafProps) => JSX.Element;

--- a/packages/core/src/types/SlatePlugin/SlatePlugin.ts
+++ b/packages/core/src/types/SlatePlugin/SlatePlugin.ts
@@ -20,7 +20,7 @@ export interface SlatePluginKey {
 /**
  * Slate plugin interface built on top of Slate and Editable.
  */
-export interface SlatePlugin {
+export interface SlatePlugin<T extends SPEditor = SPEditor> {
   /**
    * Editor method overriders
    */
@@ -29,47 +29,47 @@ export interface SlatePlugin {
   /**
    * @see {@link OnChange}
    */
-  onChange?: OnChange;
+  onChange?: OnChange<T>;
 
   /**
    * Inline element types
    */
-  inlineTypes?: (editor: SPEditor) => string[];
+  inlineTypes?: (editor: T) => string[];
 
   /**
    * Void element types
    */
-  voidTypes?: (editor: SPEditor) => string[];
+  voidTypes?: (editor: T) => string[];
 
   /**
    * @see {@link Decorate}
    */
-  decorate?: Decorate;
+  decorate?: Decorate<T>;
 
   /**
    * @see {@link RenderElement}
    */
-  renderElement?: RenderElement;
+  renderElement?: RenderElement<T>;
 
   /**
    * @see {@link RenderLeaf}
    */
-  renderLeaf?: RenderLeaf;
+  renderLeaf?: RenderLeaf<T>;
 
   /**
    * @see {@link OnKeyDown}
    */
-  onKeyDown?: OnKeyDown | null;
+  onKeyDown?: OnKeyDown<T> | null;
 
   /**
    * @see {@link OnDOMBeforeInput}
    */
-  onDOMBeforeInput?: OnDOMBeforeInput;
+  onDOMBeforeInput?: OnDOMBeforeInput<T>;
 
   /**
    * @see {@link DeserializeHtml}
    */
-  deserialize?: Deserialize;
+  deserialize?: Deserialize<T>;
 
   /**
    * @see {@link SerializeHtml}


### PR DESCRIPTION
## Issue

When building a plugin with a custom editor type, the typing for callback functions (`renderElement`, `onChange`, etc) cannot be changed when using the `SlatePlugin` interface.

## What I did

I added a generic to the `SlatePlugin` interface and all callback functions (`renderElement`, `onChange`, etc), defaulting it to `SPEditor`. This will maintain the current typings but allow for custom typing as well.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->