### PR TITLE
Add additional typings to avoid casting when working with a custom editor

### DIFF
--- a/packages/core/src/components/SlatePlugins.tsx
+++ b/packages/core/src/components/SlatePlugins.tsx
@@ -14,7 +14,10 @@ export interface SlatePluginsProps<T extends SPEditor = SPEditor>
   editableProps?: EditableProps;
 }
 
-export const SlatePlugins = <T extends SPEditor = SPEditor>({ children, ...options }: SlatePluginsProps<T>) => {
+export const SlatePlugins = <T extends SPEditor = SPEditor>({
+  children,
+  ...options
+}: SlatePluginsProps<T>) => {
   const { slateProps, editableProps } = useSlatePlugins(options);
 
   if (!slateProps.editor) return null;

--- a/packages/core/src/components/SlatePlugins.tsx
+++ b/packages/core/src/components/SlatePlugins.tsx
@@ -3,17 +3,18 @@ import { Editable, Slate } from 'slate-react';
 import { EditableProps } from 'slate-react/dist/components/editable';
 import { useSlatePlugins } from '../hooks/useSlatePlugins/useSlatePlugins';
 import { SlateProps } from '../types/SlateProps';
+import { SPEditor } from '../types/SPEditor';
 import { UseSlatePluginsEffectsOptions } from '../types/UseSlatePluginsEffectsOptions';
 import { UseSlatePropsOptions } from '../types/UseSlatePropsOptions';
 
-export interface SlatePluginsProps
-  extends UseSlatePluginsEffectsOptions,
+export interface SlatePluginsProps<T extends SPEditor = SPEditor>
+  extends UseSlatePluginsEffectsOptions<T>,
     UseSlatePropsOptions {
   children?: React.ReactNode;
   editableProps?: EditableProps;
 }
 
-export const SlatePlugins = ({ children, ...options }: SlatePluginsProps) => {
+export const SlatePlugins = <T extends SPEditor = SPEditor>({ children, ...options }: SlatePluginsProps<T>) => {
   const { slateProps, editableProps } = useSlatePlugins(options);
 
   if (!slateProps.editor) return null;

--- a/packages/core/src/hooks/useSlatePlugins/useSlatePlugins.ts
+++ b/packages/core/src/hooks/useSlatePlugins/useSlatePlugins.ts
@@ -1,3 +1,4 @@
+import { SPEditor } from '../../types/SPEditor';
 import { UseSlatePluginsOptions } from '../../types/UseSlatePluginsOptions';
 import { useEditableProps } from './useEditableProps';
 import { useSlatePluginsEffects } from './useSlatePluginsEffects';
@@ -7,7 +8,7 @@ import { useSlateProps } from './useSlateProps';
  * Run `useSlatePluginsEffects` and props getter for `Slate` and `Editable` components.
  * Use `useSlatePluginsStore` to select store state.
  */
-export const useSlatePlugins = ({
+export const useSlatePlugins = <T extends SPEditor = SPEditor>({
   id,
   components,
   editor,
@@ -17,7 +18,7 @@ export const useSlatePlugins = ({
   plugins,
   onChange,
   editableProps,
-}: UseSlatePluginsOptions) => {
+}: UseSlatePluginsOptions<T>) => {
   useSlatePluginsEffects({
     id,
     components,

--- a/packages/core/src/hooks/useSlatePlugins/useSlatePluginsEffects.ts
+++ b/packages/core/src/hooks/useSlatePlugins/useSlatePluginsEffects.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { createEditor } from 'slate';
+import { createEditor, Editor } from 'slate';
 import { createHistoryPlugin } from '../../plugins/createHistoryPlugin';
 import { createReactPlugin } from '../../plugins/createReactPlugin';
 import { useSlatePluginsActions } from '../../store/useSlatePluginsActions';
@@ -8,6 +8,7 @@ import {
   useStoreEditorEnabled,
   useStoreSlatePlugins,
 } from '../../store/useSlatePluginsSelectors';
+import { SPEditor } from '../../types/SPEditor';
 import { UseSlatePluginsEffectsOptions } from '../../types/UseSlatePluginsEffectsOptions';
 import { flatMapByKey } from '../../utils/flatMapByKey';
 import { pipe } from '../../utils/pipe';
@@ -17,7 +18,7 @@ import { withSlatePlugins } from '../../utils/withSlatePlugins';
  * Effects to update the slate plugins store from the options.
  * Dynamically updating the options will update the store state.
  */
-export const useSlatePluginsEffects = ({
+export const useSlatePluginsEffects = <T extends SPEditor = SPEditor>({
   id = 'main',
   value,
   editor,
@@ -26,7 +27,7 @@ export const useSlatePluginsEffects = ({
   options,
   initialValue,
   plugins,
-}: UseSlatePluginsEffectsOptions) => {
+}: UseSlatePluginsEffectsOptions<T>) => {
   const {
     setInitialState,
     setValue,
@@ -35,7 +36,7 @@ export const useSlatePluginsEffects = ({
     setPluginKeys,
     setEnabled,
     clearState,
-  } = useSlatePluginsActions(id);
+  } = useSlatePluginsActions<T>(id);
   const storeEditor = useStoreEditor(id);
   const storeEnabled = useStoreEditorEnabled(id);
   const storePlugins = useStoreSlatePlugins(id);
@@ -93,9 +94,14 @@ export const useSlatePluginsEffects = ({
   useEffect(() => {
     if (!storeEditor && storeEnabled) {
       setEditor(
-        pipe(
+        pipe<Editor, T>(
           editor ?? createEditor(),
-          withSlatePlugins({ id, plugins: storePlugins, options, components })
+          withSlatePlugins<T>({
+            id,
+            plugins: storePlugins,
+            options,
+            components,
+          })
         )
       );
     }

--- a/packages/core/src/plugins/createInlineVoidPlugin.ts
+++ b/packages/core/src/plugins/createInlineVoidPlugin.ts
@@ -5,8 +5,8 @@ import { SPEditor } from '../types/SPEditor';
 import { TElement } from '../types/TElement';
 import { getSlatePluginWithOverrides } from '../utils/getSlatePluginWithOverrides';
 
-export interface WithInlineVoidOptions {
-  plugins?: SlatePlugin[];
+export interface WithInlineVoidOptions<T extends SPEditor = SPEditor> {
+  plugins?: SlatePlugin<T>[];
   inlineTypes?: string[];
   voidTypes?: string[];
 }
@@ -15,11 +15,11 @@ export interface WithInlineVoidOptions {
  * Merge and register all the inline types and void types from the plugins and options,
  * using `editor.isInline` and `editor.isVoid`
  */
-export const withInlineVoid = ({
+export const withInlineVoid = <T extends SPEditor = SPEditor>({
   plugins = [],
   inlineTypes = [],
   voidTypes = [],
-}: WithInlineVoidOptions): WithOverride<SPEditor> => (editor) => {
+}: WithInlineVoidOptions<T>): WithOverride<T> => (editor) => {
   const { isInline } = editor;
   const { isVoid } = editor;
 

--- a/packages/core/src/store/useSlatePluginsActions.ts
+++ b/packages/core/src/store/useSlatePluginsActions.ts
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
-import { createEditor } from 'slate';
+import { createEditor, Editor } from 'slate';
 import shallow from 'zustand/shallow';
-import { SlatePluginsActions, State } from '../types/SlatePluginsStore';
+import {
+  SlatePluginsActions,
+  SlatePluginsState,
+  State,
+} from '../types/SlatePluginsStore';
 import { SPEditor } from '../types/SPEditor';
 import { pipe } from '../utils/pipe';
 import { withSlatePlugins } from '../utils/withSlatePlugins';
@@ -13,19 +17,19 @@ import { getSetStateByKey } from './zustand.utils';
 
 const { getState: get, setState: set } = slatePluginsStore;
 
-export const useSlatePluginsActions = (
+export const useSlatePluginsActions = <T extends SPEditor = SPEditor>(
   storeId?: string | null
-): SlatePluginsActions => {
+): SlatePluginsActions<T> => {
   const storeKeys = useSlatePluginsStore((s) => Object.keys(s), shallow);
 
   const stateId: string | undefined = storeId ?? storeKeys[0];
 
   return useMemo(() => {
-    const setEditor: SlatePluginsActions['setEditor'] = getSetStateByKey<
-      State['editor']
+    const setEditor: SlatePluginsActions<T>['setEditor'] = getSetStateByKey<
+      State<T>['editor']
     >('editor', stateId);
 
-    const setValue = getSetStateByKey<State['value']>('value', stateId);
+    const setValue = getSetStateByKey<State<T>['value']>('value', stateId);
 
     return {
       setEditor,
@@ -45,7 +49,7 @@ export const useSlatePluginsActions = (
         id = stateId
       ) =>
         id &&
-        set((state) => {
+        set((state: SlatePluginsState<T>) => {
           if (state[id]) return;
 
           state[id] = {
@@ -61,20 +65,20 @@ export const useSlatePluginsActions = (
         const { editor, plugins } = state;
 
         setEditor(
-          pipe(
+          pipe<Editor, T>(
             createEditor(),
-            withSlatePlugins({
+            withSlatePlugins<T>({
               id,
               plugins,
-              options: (editor as SPEditor).options,
+              options: editor?.options,
             })
           ),
           id
         );
       },
-      setEnabled: getSetStateByKey<State['enabled']>('enabled', stateId),
-      setPlugins: getSetStateByKey<State['plugins']>('plugins', stateId),
-      setPluginKeys: getSetStateByKey<State['pluginKeys']>(
+      setEnabled: getSetStateByKey<State<T>['enabled']>('enabled', stateId),
+      setPlugins: getSetStateByKey<State<T>['plugins']>('plugins', stateId),
+      setPluginKeys: getSetStateByKey<State<T>['pluginKeys']>(
         'pluginKeys',
         stateId
       ),

--- a/packages/core/src/types/SlatePluginsStore.ts
+++ b/packages/core/src/types/SlatePluginsStore.ts
@@ -2,11 +2,11 @@ import { SlatePlugin } from './SlatePlugin/SlatePlugin';
 import { SPEditor } from './SPEditor';
 import { TDescendant } from './TDescendant';
 
-export type State = {
+export type State<T extends SPEditor = SPEditor> = {
   /**
    * Slate editor. Default uses `withReact`, `withHistoryPersist` and `withRandomKey` plugins.
    */
-  editor?: SPEditor;
+  editor?: T;
 
   /**
    * If true, slate plugins will create the editor.
@@ -18,7 +18,7 @@ export type State = {
   /**
    * Slate plugins. Default is [].
    */
-  plugins: SlatePlugin[];
+  plugins: SlatePlugin<T>[];
 
   /**
    * Element keys used by the plugins
@@ -31,9 +31,12 @@ export type State = {
   value: TDescendant[];
 };
 
-export type SlatePluginsState = Record<string, State>;
+export type SlatePluginsState<T extends SPEditor = SPEditor> = Record<
+  string,
+  State<T>
+>;
 
-export type SlatePluginsActions = {
+export type SlatePluginsActions<T extends SPEditor = SPEditor> = {
   /**
    * Remove state by id. Called by SlatePlugins on unmount.
    */
@@ -42,16 +45,16 @@ export type SlatePluginsActions = {
   /**
    * Set initial state by id. Called by SlatePlugins on mount.
    */
-  setInitialState: (value?: Partial<State>, id?: string) => void;
+  setInitialState: (value?: Partial<State<T>>, id?: string) => void;
 
   /**
    * Set a new editor with slate plugins.
    */
   resetEditor: (id?: string) => void;
 
-  setEditor: (value: State['editor'], id?: string) => void;
-  setEnabled: (value: State['enabled'], id?: string) => void;
-  setPlugins: (value: State['plugins'], id?: string) => void;
-  setPluginKeys: (value: State['pluginKeys'], id?: string) => void;
-  setValue: (value: State['value'], id?: string) => void;
+  setEditor: (value: State<T>['editor'], id?: string) => void;
+  setEnabled: (value: State<T>['enabled'], id?: string) => void;
+  setPlugins: (value: State<T>['plugins'], id?: string) => void;
+  setPluginKeys: (value: State<T>['pluginKeys'], id?: string) => void;
+  setValue: (value: State<T>['value'], id?: string) => void;
 };

--- a/packages/core/src/types/UseSlatePluginsEffectsOptions.ts
+++ b/packages/core/src/types/UseSlatePluginsEffectsOptions.ts
@@ -1,21 +1,16 @@
 import { SlatePluginsOptions } from './SlatePluginOptions/SlatePluginsOptions';
 import { State } from './SlatePluginsStore';
-import { TEditor } from './TEditor';
+import { SPEditor } from './SPEditor';
 
 /**
  * `useSlatePluginsEffects` options
  */
-export interface UseSlatePluginsEffectsOptions
-  extends Partial<Pick<State, 'value' | 'enabled' | 'plugins'>> {
+export interface UseSlatePluginsEffectsOptions<T extends SPEditor = SPEditor>
+  extends Partial<Pick<State<T>, 'editor' | 'value' | 'enabled' | 'plugins'>> {
   /**
    * Unique id to store multiple editor states. Default is 'main'.
    */
   id?: string;
-
-  /**
-   * Controlled editor.
-   */
-  editor?: TEditor;
 
   /**
    * Initial value of the editor.

--- a/packages/core/src/types/UseSlatePluginsOptions.ts
+++ b/packages/core/src/types/UseSlatePluginsOptions.ts
@@ -1,3 +1,4 @@
+import { SPEditor } from './SPEditor';
 import { UseEditablePropsOptions } from './UseEditablePropsOptions';
 import { UseSlatePluginsEffectsOptions } from './UseSlatePluginsEffectsOptions';
 import { UseSlatePropsOptions } from './UseSlatePropsOptions';
@@ -5,6 +6,8 @@ import { UseSlatePropsOptions } from './UseSlatePropsOptions';
 /**
  * `useSlatePlugins` options
  */
-export type UseSlatePluginsOptions = UseSlatePropsOptions &
+export type UseSlatePluginsOptions<
+  T extends SPEditor = SPEditor
+> = UseSlatePropsOptions &
   UseEditablePropsOptions &
-  UseSlatePluginsEffectsOptions;
+  UseSlatePluginsEffectsOptions<T>;

--- a/packages/core/src/utils/getInlineTypes.ts
+++ b/packages/core/src/utils/getInlineTypes.ts
@@ -4,9 +4,9 @@ import { SPEditor } from '../types/SPEditor';
 /**
  * Get inline types from the plugins
  */
-export const getInlineTypes = (
-  editor: SPEditor,
-  plugins: SlatePlugin[]
+export const getInlineTypes = <T extends SPEditor = SPEditor>(
+  editor: T,
+  plugins: SlatePlugin<T>[]
 ): string[] => {
   return plugins.flatMap((p) => p.inlineTypes?.(editor) ?? []);
 };

--- a/packages/core/src/utils/getSlatePluginWithOverrides.ts
+++ b/packages/core/src/utils/getSlatePluginWithOverrides.ts
@@ -1,10 +1,12 @@
 /**
  * Helper to get a slate plugin returning `withOverrides`
  */
+import { WithOverride } from '../types';
 import { SlatePlugin } from '../types/SlatePlugin/SlatePlugin';
+import { SPEditor } from '../types/SPEditor';
 
-export const getSlatePluginWithOverrides = <T extends (...args: any) => any>(
-  withOverrides: T
-) => (options?: Parameters<T>[0]): SlatePlugin => ({
+export const getSlatePluginWithOverrides = <T extends SPEditor = SPEditor>(
+  withOverrides: (...args: any) => WithOverride<T>
+) => (options?: Parameters<typeof withOverrides>[0]): SlatePlugin<T> => ({
   withOverrides: withOverrides(options),
 });

--- a/packages/core/src/utils/withSlatePlugins.ts
+++ b/packages/core/src/utils/withSlatePlugins.ts
@@ -9,9 +9,9 @@ import { SPEditor } from '../types/SPEditor';
 import { flatMapByKey } from './flatMapByKey';
 import { pipe } from './pipe';
 
-export interface WithSlatePluginsOptions {
+export interface WithSlatePluginsOptions<T extends SPEditor = SPEditor> {
   id?: string;
-  plugins?: SlatePlugin[];
+  plugins?: SlatePlugin<T>[];
   options?: SlatePluginsOptions;
   components?: Record<string, ReactNode>;
 }
@@ -23,13 +23,13 @@ export interface WithSlatePluginsOptions {
  * - `key`: random key for the <Slate> component so each time the editor is created, the component resets.
  * - `options`: {@link SlatePluginsOptions}
  */
-export const withSlatePlugins = <TOutput = {}>({
+export const withSlatePlugins = <T extends SPEditor = SPEditor>({
   id = 'main',
   plugins = [createReactPlugin(), createHistoryPlugin()],
   options = {},
   components = {},
-}: WithSlatePluginsOptions = {}) => <T extends Editor>(e: T) => {
-  let editor = e as T & SPEditor & TOutput;
+}: WithSlatePluginsOptions<T> = {}) => <E extends Editor>(e: E) => {
+  let editor = e as T & E;
   editor.id = id;
 
   if (components) {

--- a/packages/elements/image-ui/src/ToolbarImage/ToolbarImage.fixtures.tsx
+++ b/packages/elements/image-ui/src/ToolbarImage/ToolbarImage.fixtures.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
 import * as React from 'react';
+import { SPEditor } from '@udecode/slate-plugins-core';
 import { jsx } from '@udecode/slate-plugins-test-utils';
 import { Editor } from 'slate';
 
@@ -13,7 +14,7 @@ export const input1 = ((
       <cursor />
     </hp>
   </editor>
-) as any) as Editor;
+) as any) as SPEditor;
 
 export const output1 = (
   <editor>

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html-empty.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html-empty.spec.tsx
@@ -1,7 +1,8 @@
 /** @jsx jsx */
-
+import { SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
 import { jsx } from '@udecode/slate-plugins-test-utils';
 import { Editor } from 'slate';
+import { ReactEditor } from 'slate-react';
 import { createBoldPlugin } from '../../../../../../marks/basic-marks/src/bold/createBoldPlugin';
 import { createEditorPlugins } from '../../../../../../slate-plugins/src/utils/createEditorPlugins';
 import { createDeserializeHTMLPlugin } from '../../createDeserializeHTMLPlugin';
@@ -33,7 +34,7 @@ const output = (
 
 describe('when inserting empty html', () => {
   it('should do nothing', () => {
-    const plugins = [createBoldPlugin()];
+    const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createBoldPlugin()];
     plugins.push(createDeserializeHTMLPlugin({ plugins }));
     const editor = createEditorPlugins({
       editor: input,

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html.spec.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
-import { jsx } from '@udecode/slate-plugins-test-utils';
 import { SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
+import { jsx } from '@udecode/slate-plugins-test-utils';
 import { Editor } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { createHeadingPlugin } from '../../../../../../elements/heading/src/createHeadingPlugin';
@@ -36,7 +36,9 @@ describe('when inserting html', () => {
         </editor>
       ) as any;
 
-      const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createHeadingPlugin()];
+      const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [
+        createHeadingPlugin(),
+      ];
       plugins.push(createDeserializeHTMLPlugin({ plugins }));
       const editor = createEditorPlugins({
         editor: input,
@@ -68,7 +70,9 @@ describe('when inserting html', () => {
         </editor>
       ) as any;
 
-      const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createHeadingPlugin()];
+      const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [
+        createHeadingPlugin(),
+      ];
       plugins.push(createDeserializeHTMLPlugin({ plugins }));
       const editor = createEditorPlugins({
         editor: input,

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html.spec.tsx
@@ -1,7 +1,9 @@
 /** @jsx jsx */
 
 import { jsx } from '@udecode/slate-plugins-test-utils';
+import { SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
 import { Editor } from 'slate';
+import { ReactEditor } from 'slate-react';
 import { createHeadingPlugin } from '../../../../../../elements/heading/src/createHeadingPlugin';
 import { createEditorPlugins } from '../../../../../../slate-plugins/src/utils/createEditorPlugins';
 import { createDeserializeHTMLPlugin } from '../../createDeserializeHTMLPlugin';
@@ -34,7 +36,7 @@ describe('when inserting html', () => {
         </editor>
       ) as any;
 
-      const plugins = [createHeadingPlugin()];
+      const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createHeadingPlugin()];
       plugins.push(createDeserializeHTMLPlugin({ plugins }));
       const editor = createEditorPlugins({
         editor: input,
@@ -66,7 +68,7 @@ describe('when inserting html', () => {
         </editor>
       ) as any;
 
-      const plugins = [createHeadingPlugin()];
+      const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createHeadingPlugin()];
       plugins.push(createDeserializeHTMLPlugin({ plugins }));
       const editor = createEditorPlugins({
         editor: input,

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/iframe-without-src.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/iframe-without-src.spec.tsx
@@ -34,7 +34,9 @@ const output = (
 
 describe('when inserting an iframe', () => {
   it('should do nothing', () => {
-    const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createMediaEmbedPlugin()];
+    const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [
+      createMediaEmbedPlugin(),
+    ];
     plugins.push(createDeserializeHTMLPlugin({ plugins }));
 
     const editor = createEditorPlugins({

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/iframe-without-src.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/iframe-without-src.spec.tsx
@@ -1,6 +1,8 @@
 /** @jsx jsx */
+import { SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
 import { jsx } from '@udecode/slate-plugins-test-utils';
 import { Editor } from 'slate';
+import { ReactEditor } from 'slate-react';
 import { createMediaEmbedPlugin } from '../../../../../../elements/media-embed/src/createMediaEmbedPlugin';
 import { createEditorPlugins } from '../../../../../../slate-plugins/src/utils/createEditorPlugins';
 import { createDeserializeHTMLPlugin } from '../../createDeserializeHTMLPlugin';
@@ -32,7 +34,7 @@ const output = (
 
 describe('when inserting an iframe', () => {
   it('should do nothing', () => {
-    const plugins = [createMediaEmbedPlugin()];
+    const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createMediaEmbedPlugin()];
     plugins.push(createDeserializeHTMLPlugin({ plugins }));
 
     const editor = createEditorPlugins({

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/inline.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/inline.spec.tsx
@@ -35,7 +35,10 @@ const output = (
 ) as any;
 
 it('should do nothing', () => {
-  const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createParagraphPlugin(), createLinkPlugin()];
+  const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [
+    createParagraphPlugin(),
+    createLinkPlugin(),
+  ];
   plugins.push(createDeserializeHTMLPlugin({ plugins }));
 
   const editor = createEditorPlugins({

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/inline.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/inline.spec.tsx
@@ -1,6 +1,8 @@
 /** @jsx jsx */
+import { SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
 import { jsx } from '@udecode/slate-plugins-test-utils';
 import { Editor } from 'slate';
+import { ReactEditor } from 'slate-react';
 import { createLinkPlugin } from '../../../../../../elements/link/src/createLinkPlugin';
 import { createParagraphPlugin } from '../../../../../../elements/paragraph/src/createParagraphPlugin';
 import { createEditorPlugins } from '../../../../../../slate-plugins/src/utils/createEditorPlugins';
@@ -33,7 +35,7 @@ const output = (
 ) as any;
 
 it('should do nothing', () => {
-  const plugins = [createParagraphPlugin(), createLinkPlugin()];
+  const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [createParagraphPlugin(), createLinkPlugin()];
   plugins.push(createDeserializeHTMLPlugin({ plugins }));
 
   const editor = createEditorPlugins({

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -12,8 +12,8 @@ import { Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { deserializeHTMLToDocumentFragment } from './utils/deserializeHTMLToDocumentFragment';
 
-export interface WithDeserializeHTMLOptions {
-  plugins?: SlatePlugin[];
+export interface WithDeserializeHTMLOptions<T extends SPEditor = SPEditor & ReactEditor> {
+  plugins?: SlatePlugin<T>[];
 
   /**
    * Function called before inserting the deserialized html.
@@ -32,10 +32,10 @@ export interface WithDeserializeHTMLOptions {
 /**
  * Enables support for deserializing inserted content from HTML format to Slate format.
  */
-export const withDeserializeHTML = ({
+export const withDeserializeHTML = <T extends ReactEditor & SPEditor = ReactEditor & SPEditor>({
   plugins = [],
   ...options
-}: WithDeserializeHTMLOptions = {}): WithOverride<ReactEditor & SPEditor> => (
+}: WithDeserializeHTMLOptions<T> = {}): WithOverride<T> => (
   editor
 ) => {
   const { insertData } = editor;

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -12,7 +12,9 @@ import { Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { deserializeHTMLToDocumentFragment } from './utils/deserializeHTMLToDocumentFragment';
 
-export interface WithDeserializeHTMLOptions<T extends SPEditor = SPEditor & ReactEditor> {
+export interface WithDeserializeHTMLOptions<
+  T extends SPEditor = SPEditor & ReactEditor
+> {
   plugins?: SlatePlugin<T>[];
 
   /**
@@ -32,12 +34,12 @@ export interface WithDeserializeHTMLOptions<T extends SPEditor = SPEditor & Reac
 /**
  * Enables support for deserializing inserted content from HTML format to Slate format.
  */
-export const withDeserializeHTML = <T extends ReactEditor & SPEditor = ReactEditor & SPEditor>({
+export const withDeserializeHTML = <
+  T extends ReactEditor & SPEditor = ReactEditor & SPEditor
+>({
   plugins = [],
   ...options
-}: WithDeserializeHTMLOptions<T> = {}): WithOverride<T> => (
-  editor
-) => {
+}: WithDeserializeHTMLOptions<T> = {}): WithOverride<T> => (editor) => {
   const { insertData } = editor;
 
   const {

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLElement.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLElement.ts
@@ -5,13 +5,13 @@ import { deserializeHTMLNode } from './deserializeHTMLNode';
 /**
  * Deserialize HTML element.
  */
-export const deserializeHTMLElement = (
-  editor: SPEditor,
+export const deserializeHTMLElement = <T extends SPEditor = SPEditor>(
+  editor: T,
   {
     plugins,
     element,
   }: {
-    plugins: SlatePlugin[];
+    plugins: SlatePlugin<T>[];
     element: HTMLElement;
   }
 ): DeserializeHTMLReturn => {

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLNode.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLNode.ts
@@ -9,9 +9,9 @@ import { deserializeHTMLToText } from './deserializeHTMLToText';
 /**
  * Deserialize HTML element or child node.
  */
-export const deserializeHTMLNode = (
-  editor: SPEditor,
-  plugins: SlatePlugin[]
+export const deserializeHTMLNode = <T extends SPEditor = SPEditor>(
+  editor: T,
+  plugins: SlatePlugin<T>[]
 ) => (node: HTMLElement | ChildNode): DeserializeHTMLReturn => {
   // text node
   const textNode = deserializeHTMLToText(node);

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
@@ -10,13 +10,13 @@ import { deserializeHTMLElement } from './deserializeHTMLElement';
 /**
  * Deserialize HTML element to a valid document fragment.
  */
-export const deserializeHTMLToDocumentFragment = (
-  editor: SPEditor,
+export const deserializeHTMLToDocumentFragment = <T extends SPEditor = SPEditor>(
+  editor: T,
   {
     plugins,
     element,
   }: {
-    plugins: SlatePlugin[];
+    plugins: SlatePlugin<T>[];
     element: HTMLElement | string;
   }
 ): TDescendant[] => {

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
@@ -10,7 +10,9 @@ import { deserializeHTMLElement } from './deserializeHTMLElement';
 /**
  * Deserialize HTML element to a valid document fragment.
  */
-export const deserializeHTMLToDocumentFragment = <T extends SPEditor = SPEditor>(
+export const deserializeHTMLToDocumentFragment = <
+  T extends SPEditor = SPEditor
+>(
   editor: T,
   {
     plugins,

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToElement.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToElement.ts
@@ -12,14 +12,14 @@ jsx;
 /**
  * Deserialize HTML to Element.
  */
-export const deserializeHTMLToElement = (
-  editor: SPEditor,
+export const deserializeHTMLToElement = <T extends SPEditor = SPEditor>(
+  editor: T,
   {
     plugins,
     element,
     children,
   }: {
-    plugins: SlatePlugin[];
+    plugins: SlatePlugin<T>[];
     element: HTMLElement;
     children: DeserializeHTMLChildren[];
   }

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToMarks.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToMarks.ts
@@ -11,8 +11,8 @@ import { DeserializeHTMLChildren } from '../types';
 
 jsx;
 
-export interface DeserializeMarksProps {
-  plugins: SlatePlugin[];
+export interface DeserializeMarksProps<T extends SPEditor = SPEditor> {
+  plugins: SlatePlugin<T>[];
   element: HTMLElement;
   children: DeserializeHTMLChildren[];
 }
@@ -21,9 +21,9 @@ export interface DeserializeMarksProps {
  * Deserialize HTML to TDescendant[] with marks on Text.
  * Build the leaf from the leaf deserializers of each plugin.
  */
-export const deserializeHTMLToMarks = (
-  editor: SPEditor,
-  { plugins, element, children }: DeserializeMarksProps
+export const deserializeHTMLToMarks = <T extends SPEditor = SPEditor>(
+  editor: T,
+  { plugins, element, children }: DeserializeMarksProps<T>
 ) => {
   let leaf = {};
 

--- a/packages/slate-plugins/src/__tests__/all-plugins.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/all-plugins.spec.tsx
@@ -8,6 +8,7 @@ import {
   SlatePlugins,
   SPEditor,
 } from '@udecode/slate-plugins-core';
+import { ReactEditor } from 'slate-react';
 import { optionsAutoformat } from '../../../../stories/config/autoformatRules';
 import { initialValuePlayground } from '../../../../stories/config/initialValues';
 import {
@@ -59,7 +60,6 @@ import { createTrailingBlockPlugin } from '../../../trailing-block/src/createTra
 import { HeadingToolbar } from '../../../ui/toolbar/src/HeadingToolbar/HeadingToolbar';
 import { createSlatePluginsComponents } from '../utils/createSlatePluginsComponents';
 import { createSlatePluginsOptions } from '../utils/createSlatePluginsOptions';
-import { ReactEditor } from 'slate-react';
 
 const components = createSlatePluginsComponents();
 const options = createSlatePluginsOptions();

--- a/packages/slate-plugins/src/__tests__/all-plugins.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/all-plugins.spec.tsx
@@ -4,7 +4,9 @@ import { render } from '@testing-library/react';
 import {
   createHistoryPlugin,
   createReactPlugin,
+  SlatePlugin,
   SlatePlugins,
+  SPEditor,
 } from '@udecode/slate-plugins-core';
 import { optionsAutoformat } from '../../../../stories/config/autoformatRules';
 import { initialValuePlayground } from '../../../../stories/config/initialValues';
@@ -57,6 +59,7 @@ import { createTrailingBlockPlugin } from '../../../trailing-block/src/createTra
 import { HeadingToolbar } from '../../../ui/toolbar/src/HeadingToolbar/HeadingToolbar';
 import { createSlatePluginsComponents } from '../utils/createSlatePluginsComponents';
 import { createSlatePluginsOptions } from '../utils/createSlatePluginsOptions';
+import { ReactEditor } from 'slate-react';
 
 const components = createSlatePluginsComponents();
 const options = createSlatePluginsOptions();
@@ -67,7 +70,7 @@ const SlatePluginsContainer = () => {
     optionsMentionPlugin
   );
 
-  const plugins = [
+  const plugins: SlatePlugin<SPEditor & ReactEditor>[] = [
     createReactPlugin(),
     createHistoryPlugin(),
     createBlockquotePlugin(),

--- a/packages/slate-plugins/src/utils/createEditorPlugins.ts
+++ b/packages/slate-plugins/src/utils/createEditorPlugins.ts
@@ -26,14 +26,14 @@ import {
  * - options
  * - components
  */
-export const createEditorPlugins = <T extends string = string>({
+export const createEditorPlugins = <E extends SPEditor & ReactEditor = SPEditor & ReactEditor, T extends string = string>({
   editor = createEditor(),
   plugins = [],
   options,
   components,
 }: {
   editor?: TEditor;
-  plugins?: SlatePlugin[];
+  plugins?: SlatePlugin<E>[];
   options?: Partial<
     Record<DefaultSlatePluginKey | T, Partial<SlatePluginOptions>>
   >;
@@ -41,7 +41,7 @@ export const createEditorPlugins = <T extends string = string>({
     Record<DefaultSlatePluginKey | T, FunctionComponent<any>>
   >;
 } = {}) => {
-  return withSlatePlugins<SPEditor & ReactEditor>({
+  return withSlatePlugins<E>({
     plugins: [createReactPlugin(), createHistoryPlugin(), ...plugins],
     options: createSlatePluginsOptions(options),
     components: createSlatePluginsComponents(components),

--- a/packages/slate-plugins/src/utils/createEditorPlugins.ts
+++ b/packages/slate-plugins/src/utils/createEditorPlugins.ts
@@ -26,7 +26,10 @@ import {
  * - options
  * - components
  */
-export const createEditorPlugins = <E extends SPEditor & ReactEditor = SPEditor & ReactEditor, T extends string = string>({
+export const createEditorPlugins = <
+  E extends SPEditor & ReactEditor = SPEditor & ReactEditor,
+  T extends string = string
+>({
   editor = createEditor(),
   plugins = [],
   options,

--- a/packages/slate-plugins/src/utils/createEditorPlugins.ts
+++ b/packages/slate-plugins/src/utils/createEditorPlugins.ts
@@ -5,6 +5,7 @@ import {
   createReactPlugin,
   SlatePlugin,
   SlatePluginOptions,
+  SPEditor,
   TEditor,
   withSlatePlugins,
 } from '@udecode/slate-plugins-core';
@@ -40,7 +41,7 @@ export const createEditorPlugins = <T extends string = string>({
     Record<DefaultSlatePluginKey | T, FunctionComponent<any>>
   >;
 } = {}) => {
-  return withSlatePlugins<ReactEditor>({
+  return withSlatePlugins<SPEditor & ReactEditor>({
     plugins: [createReactPlugin(), createHistoryPlugin(), ...plugins],
     options: createSlatePluginsOptions(options),
     components: createSlatePluginsComponents(components),

--- a/stories/deserializers/deserialize-html.stories.tsx
+++ b/stories/deserializers/deserialize-html.stories.tsx
@@ -1,9 +1,4 @@
 import React, { useMemo } from 'react';
-import { ReactEditor } from 'slate-react';
-import {
-  SlatePlugin,
-  SPEditor
-} from '@udecode/slate-plugins-core';
 import {
   createBasicElementPlugins,
   createBasicMarkPlugins,
@@ -23,6 +18,8 @@ import {
   SlatePlugins,
   useMentionPlugin,
 } from '@udecode/slate-plugins';
+import { SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
+import { ReactEditor } from 'slate-react';
 import { initialValuePasteHtml } from '../config/initialValues';
 import { editableProps, optionsSoftBreakPlugin } from '../config/pluginOptions';
 

--- a/stories/deserializers/deserialize-html.stories.tsx
+++ b/stories/deserializers/deserialize-html.stories.tsx
@@ -1,4 +1,9 @@
 import React, { useMemo } from 'react';
+import { ReactEditor } from 'slate-react';
+import {
+  SlatePlugin,
+  SPEditor
+} from '@udecode/slate-plugins-core';
 import {
   createBasicElementPlugins,
   createBasicMarkPlugins,
@@ -34,7 +39,7 @@ export const Example = () => {
   const { plugin: mentionPlugin } = useMentionPlugin();
 
   const pluginsMemo = useMemo(() => {
-    const plugins = [
+    const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [
       createReactPlugin(),
       createHistoryPlugin(),
       ...createBasicElementPlugins(),

--- a/stories/examples/playground.stories.tsx
+++ b/stories/examples/playground.stories.tsx
@@ -52,6 +52,7 @@ import {
   useMentionPlugin,
   withProps,
 } from '@udecode/slate-plugins';
+import { ReactEditor } from 'slate-react';
 import { optionsAutoformat } from '../config/autoformatRules';
 import { initialValuePlayground } from '../config/initialValues';
 import {
@@ -71,7 +72,6 @@ import {
   ToolbarButtonsTable,
 } from '../config/Toolbars';
 import { withStyledPlaceHolders } from '../config/withStyledPlaceHolders';
-import { ReactEditor } from 'slate-react';
 
 const id = 'Examples/Playground';
 

--- a/stories/examples/playground.stories.tsx
+++ b/stories/examples/playground.stories.tsx
@@ -44,6 +44,7 @@ import {
   MentionSelect,
   SlatePlugin,
   SlatePlugins,
+  SPEditor,
   ToolbarImage,
   ToolbarLink,
   ToolbarSearchHighlight,
@@ -70,6 +71,7 @@ import {
   ToolbarButtonsTable,
 } from '../config/Toolbars';
 import { withStyledPlaceHolders } from '../config/withStyledPlaceHolders';
+import { ReactEditor } from 'slate-react';
 
 const id = 'Examples/Playground';
 
@@ -95,8 +97,8 @@ export const Plugins = ({
     optionsMentionPlugin
   );
 
-  const pluginsMemo: SlatePlugin[] = useMemo(() => {
-    const plugins = [
+  const pluginsMemo = useMemo(() => {
+    const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [
       createReactPlugin(),
       createHistoryPlugin(),
       createParagraphPlugin(),


### PR DESCRIPTION
## Issue

#640 allowed for better typings for custom editor types within plugins, but it is still necessary to cast the editor and plugins to the correct type when dealing with the plugin options.

## What I did

Added generic typings around the plugin options and props, defaulting to `SPEditor`.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->