### PR TITLE
add insertMediaEmbed transform

### DIFF
--- a/packages/elements/media-embed/src/createMediaEmbedPlugin.ts
+++ b/packages/elements/media-embed/src/createMediaEmbedPlugin.ts
@@ -10,9 +10,11 @@ import { getMediaEmbedDeserialize } from './getMediaEmbedDeserialize';
  * Enables support for embeddable media such as YouTube
  * or Vimeo videos, Instagram posts and tweets or Google Maps.
  */
-export const createMediaEmbedPlugin = (): SlatePlugin => ({
-  pluginKeys: ELEMENT_MEDIA_EMBED,
-  renderElement: getRenderElement(ELEMENT_MEDIA_EMBED),
-  deserialize: getMediaEmbedDeserialize(),
-  voidTypes: getSlatePluginTypes(ELEMENT_MEDIA_EMBED),
+export const createMediaEmbedPlugin = ({
+  pluginKey = ELEMENT_MEDIA_EMBED,
+}): SlatePlugin => ({
+  pluginKeys: pluginKey,
+  renderElement: getRenderElement(pluginKey),
+  deserialize: getMediaEmbedDeserialize(pluginKey),
+  voidTypes: getSlatePluginTypes(pluginKey),
 });

--- a/packages/elements/media-embed/src/createMediaEmbedPlugin.ts
+++ b/packages/elements/media-embed/src/createMediaEmbedPlugin.ts
@@ -12,6 +12,8 @@ import { getMediaEmbedDeserialize } from './getMediaEmbedDeserialize';
  */
 export const createMediaEmbedPlugin = ({
   pluginKey = ELEMENT_MEDIA_EMBED,
+}: {
+  pluginKey?: string;
 }): SlatePlugin => ({
   pluginKeys: pluginKey,
   renderElement: getRenderElement(pluginKey),

--- a/packages/elements/media-embed/src/createMediaEmbedPlugin.ts
+++ b/packages/elements/media-embed/src/createMediaEmbedPlugin.ts
@@ -14,7 +14,7 @@ export const createMediaEmbedPlugin = ({
   pluginKey = ELEMENT_MEDIA_EMBED,
 }: {
   pluginKey?: string;
-}): SlatePlugin => ({
+} = {}): SlatePlugin => ({
   pluginKeys: pluginKey,
   renderElement: getRenderElement(pluginKey),
   deserialize: getMediaEmbedDeserialize(pluginKey),

--- a/packages/elements/media-embed/src/getMediaEmbedDeserialize.ts
+++ b/packages/elements/media-embed/src/getMediaEmbedDeserialize.ts
@@ -6,8 +6,10 @@ import {
 } from '@udecode/slate-plugins-core';
 import { ELEMENT_MEDIA_EMBED } from './defaults';
 
-export const getMediaEmbedDeserialize = (): Deserialize => (editor) => {
-  const options = getSlatePluginOptions(editor, ELEMENT_MEDIA_EMBED);
+export const getMediaEmbedDeserialize = (
+  pluginKey = ELEMENT_MEDIA_EMBED
+): Deserialize => (editor) => {
+  const options = getSlatePluginOptions(editor, pluginKey);
 
   return {
     element: getNodeDeserializer({

--- a/packages/elements/media-embed/src/transforms/index.ts
+++ b/packages/elements/media-embed/src/transforms/index.ts
@@ -1,0 +1,1 @@
+export * from './insertMediaEmbed';

--- a/packages/elements/media-embed/src/transforms/insertMediaEmbed.ts
+++ b/packages/elements/media-embed/src/transforms/insertMediaEmbed.ts
@@ -13,7 +13,7 @@ export const insertMediaEmbed = (
     url,
     pluginKey = ELEMENT_MEDIA_EMBED,
   }: {
-    url: MediaEmbedNodeData;
+    url: MediaEmbedNodeData | undefined;
   } & SlatePluginKey
 ): void => {
   if (!editor.selection) return;

--- a/packages/elements/media-embed/src/transforms/insertMediaEmbed.ts
+++ b/packages/elements/media-embed/src/transforms/insertMediaEmbed.ts
@@ -1,0 +1,32 @@
+import { getParent, insertNodes } from '@udecode/slate-plugins-common';
+import {
+  SlatePluginKey,
+  SPEditor,
+  TElement,
+} from '@udecode/slate-plugins-core';
+import { ELEMENT_MEDIA_EMBED } from '../defaults';
+import { MediaEmbedNodeData } from '../types';
+
+export const insertMediaEmbed = (
+  editor: SPEditor,
+  {
+    url,
+    pluginKey = ELEMENT_MEDIA_EMBED,
+  }: {
+    url: MediaEmbedNodeData;
+  } & SlatePluginKey
+): void => {
+  if (!editor.selection) return;
+  const selectionParentEntry = getParent(editor, editor.selection);
+  if (!selectionParentEntry) return;
+  const [, path] = selectionParentEntry;
+  insertNodes<TElement>(
+    editor,
+    {
+      type: pluginKey,
+      url,
+      children: [{ text: '' }],
+    },
+    { at: path }
+  );
+};


### PR DESCRIPTION
## Issue

The media-embed plugin did not have an insert* transform like some other plugins such as table

## What I did

Created a simple insertMediaEmbed transform which inserts a media-embed element.

Assuming this is good and lands, we should also update the toolbar examples in storybook to use it. Let me know if I should do that before we land this.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.