### PR TITLE
fix default url type for insertMediaEmbed

### DIFF
--- a/packages/elements/media-embed/src/transforms/insertMediaEmbed.ts
+++ b/packages/elements/media-embed/src/transforms/insertMediaEmbed.ts
@@ -10,11 +10,9 @@ import { MediaEmbedNodeData } from '../types';
 export const insertMediaEmbed = (
   editor: SPEditor,
   {
-    url,
+    url = '',
     pluginKey = ELEMENT_MEDIA_EMBED,
-  }: {
-    url: MediaEmbedNodeData | undefined;
-  } & SlatePluginKey
+  }: Partial<MediaEmbedNodeData> & SlatePluginKey
 ): void => {
   if (!editor.selection) return;
   const selectionParentEntry = getParent(editor, editor.selection);


### PR DESCRIPTION
## Issue

With the `insertMediaEmbed` transform I added yesterday, the default of undefined was a bad idea when working in a collaborative environment

## What I did

Switched the default type to null, updated the type defintion

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.