### PR TITLE
fix(nodeId): check if operation is in history

### DIFF
--- a/.changeset/orange-feet-cover.md
+++ b/.changeset/orange-feet-cover.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(nodeId): check if operation is in history

--- a/packages/common/src/__tests__/transforms/withNodeID/insert-nodes-with-custom-keys.spec.tsx
+++ b/packages/common/src/__tests__/transforms/withNodeID/insert-nodes-with-custom-keys.spec.tsx
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+import { jsx } from '@udecode/slate-plugins-test-utils';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withNodeId } from '../../../../../node-id/src/createNodeIdPlugin';
+import { insertNodes } from '../../../transforms/insertNodes';
+import { idCreatorFixture } from './fixtures';
+
+jsx;
+
+const input = ((
+  <editor>
+    <hp foo={10}>
+      test
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const output = (
+  <editor>
+    <hp foo={10}>test</hp>
+    <hp foo={1}>inserted</hp>
+    <hp foo={2}>inserted</hp>
+  </editor>
+) as any;
+
+it('should add an id to the new elements', () => {
+  const editor = withNodeId({ idCreator: idCreatorFixture, idKey: 'foo' })(
+    withHistory(input)
+  );
+
+  insertNodes(
+    editor,
+    (
+      <fragment>
+        <hp>inserted</hp>
+        <hp>inserted</hp>
+      </fragment>
+    ) as any
+  );
+
+  editor.undo();
+  editor.redo();
+  editor.undo();
+  editor.redo();
+
+  expect(input.children).toEqual(output.children);
+});

--- a/packages/common/src/__tests__/transforms/withNodeID/insert-nodes-with-same-id.spec.tsx
+++ b/packages/common/src/__tests__/transforms/withNodeID/insert-nodes-with-same-id.spec.tsx
@@ -1,0 +1,53 @@
+/** @jsx jsx */
+import { TElement } from '@udecode/slate-plugins-core';
+import { jsx } from '@udecode/slate-plugins-test-utils';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withNodeId } from '../../../../../node-id/src/createNodeIdPlugin';
+import { insertNodes } from '../../../transforms/insertNodes';
+import { idCreatorFixture } from './fixtures';
+
+jsx;
+
+const input = ((
+  <editor>
+    <hp id={10}>
+      test
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const output = (
+  <editor>
+    <hp id={10}>test</hp>
+    <hp id={11}>inserted</hp>
+    <hp id={2}>inserted</hp>
+  </editor>
+) as any;
+
+it('should reset the id after inserting the same node with id twice', () => {
+  const editor = withNodeId({
+    idCreator: idCreatorFixture,
+  })(withHistory(input));
+
+  insertNodes<TElement>(
+    editor,
+    (
+      <fragment>
+        <hp id={11}>inserted</hp>
+      </fragment>
+    ) as any
+  );
+
+  insertNodes<TElement>(
+    editor,
+    (
+      <fragment>
+        <hp id={11}>inserted</hp>
+      </fragment>
+    ) as any
+  );
+
+  expect(input.children).toEqual(output.children);
+});

--- a/packages/node-id/src/createNodeIdPlugin.ts
+++ b/packages/node-id/src/createNodeIdPlugin.ts
@@ -15,10 +15,6 @@ import cloneDeep from "lodash/cloneDeep"
 import { Editor, NodeEntry, Operation } from "slate"
 import { HistoryEditor } from "slate-history"
 
-export interface NodeIdEditor extends HistoryEditor {
-  removedIDs: Set<any>
-}
-
 export interface WithNodeIdProps extends QueryNodeOptions {
   /**
    * Node key to store the id.
@@ -56,14 +52,12 @@ export const withNodeId = ({
   filter = () => true,
   allow,
   exclude,
-}: WithNodeIdProps = {}): WithOverride<HistoryEditor, NodeIdEditor> => (e) => {
-  const editor = e as typeof e & NodeIdEditor
+}: WithNodeIdProps = {}): WithOverride<HistoryEditor> => (e) => {
+  const editor = e as typeof e & HistoryEditor
 
   const { apply } = editor
 
   const idPropsCreator = () => ({ [idKey]: idCreator() })
-
-  editor.removedIDs = new Set()
 
   editor.apply = (operation) => {
     if (operation.type === "insert_node") {
@@ -75,15 +69,11 @@ export const withNodeId = ({
       }
 
       const node = cloneDeep(operation.node) as TNode
-      // console.log({
-      //   node: JSON.stringify(node),
-      //   someNode: someNode(editor, { match: { id: node[idKey] } }),
-      //   operation: JSON.stringify(operation),
-      // })
-      if (someNode(editor, { match: { id: node[idKey] } })) {
-        // the id in the new node is already being used in the editor, we need to replace it with a new id
-        node[idKey] = idCreator()
-      }
+      
+      // the id in the new node is already being used in the editor, we need to replace it with a new id
+      // if (someNode(editor, { match: { [idKey]: node[idKey] } })) {
+      //   node[idKey] = idCreator()
+      // }
 
       // it will not overwrite ids once it's set as it's read-only
       const applyDeepToNodes = resetExistingID
@@ -110,13 +100,7 @@ export const withNodeId = ({
       (!filterText || (operation.properties as Partial<TNode>).type)
     ) {
       let id = operation.properties[idKey]
-      // console.log({
-      //   properties: JSON.stringify(operation.properties),
-      //   someNode: someNode(editor, {
-      //     match: { [idKey]: (operation.properties as Partial<TNode>)[idKey] },
-      //   }),
-      //   operation: JSON.stringify(operation),
-      // })
+      
       if (
         someNode(editor, {
           match: { [idKey]: (operation.properties as Partial<TNode>)[idKey] },

--- a/packages/node-id/src/createNodeIdPlugin.ts
+++ b/packages/node-id/src/createNodeIdPlugin.ts
@@ -3,49 +3,49 @@ import {
   mergeDeepToNodes,
   QueryNodeOptions,
   someNode,
-} from "@udecode/slate-plugins-common"
+} from '@udecode/slate-plugins-common';
 import {
   getSlatePluginWithOverrides,
   isDescendant,
   isElement,
   TNode,
   WithOverride,
-} from "@udecode/slate-plugins-core"
-import cloneDeep from "lodash/cloneDeep"
-import { Editor, NodeEntry, Operation } from "slate"
-import { HistoryEditor } from "slate-history"
+} from '@udecode/slate-plugins-core';
+import cloneDeep from 'lodash/cloneDeep';
+import { NodeEntry } from 'slate';
+import { HistoryEditor } from 'slate-history';
 
 export interface WithNodeIdProps extends QueryNodeOptions {
   /**
    * Node key to store the id.
    * @default 'id'
    */
-  idKey?: string
+  idKey?: string;
 
   /**
    * ID factory, e.g. `uuid`
    * @default () => Date.now()
    */
-  idCreator?: Function
+  idCreator?: Function;
 
   /**
    * Filter `Text` nodes.
    * @default true
    */
-  filterText?: boolean
+  filterText?: boolean;
 
   /**
    * The existing id is still reset even if the id already exists.
    * @default false
    */
-  resetExistingID?: boolean
+  resetExistingID?: boolean;
 }
 
 /**
  * Enables support for inserting nodes with an id key.
  */
 export const withNodeId = ({
-  idKey = "id",
+  idKey = 'id',
   idCreator = () => Date.now(),
   filterText = true,
   resetExistingID = false,
@@ -53,20 +53,20 @@ export const withNodeId = ({
   allow,
   exclude,
 }: WithNodeIdProps = {}): WithOverride<HistoryEditor> => (e) => {
-  const editor = e as typeof e & HistoryEditor
+  const editor = e as typeof e & HistoryEditor;
 
-  const { apply } = editor
+  const { apply } = editor;
 
-  const idPropsCreator = () => ({ [idKey]: idCreator() })
+  const idPropsCreator = () => ({ [idKey]: idCreator() });
 
   editor.apply = (operation) => {
-    if (operation.type === "insert_node") {
+    if (operation.type === 'insert_node') {
       const newFilter = (entry: NodeEntry<TNode>) => {
-        const [node] = entry
+        const [node] = entry;
         return filter(entry) && filterText
           ? isElement(node)
-          : isDescendant(node)
-      }
+          : isDescendant(node);
+      };
 
       const node = cloneDeep(operation.node) as TNode
       // the id in the new node is already being used in the editor, we need to replace it with a new id
@@ -77,7 +77,7 @@ export const withNodeId = ({
       // it will not overwrite ids once it's set as it's read-only
       const applyDeepToNodes = resetExistingID
         ? mergeDeepToNodes
-        : defaultsDeepToNodes
+        : defaultsDeepToNodes;
       applyDeepToNodes({
         node,
         source: idPropsCreator,
@@ -86,27 +86,27 @@ export const withNodeId = ({
           allow,
           exclude,
         },
-      })
+      });
 
       return apply({
         ...operation,
         node,
-      })
+      });
     }
 
     if (
-      operation.type === "split_node" &&
+      operation.type === 'split_node' &&
       (!filterText || (operation.properties as Partial<TNode>).type)
     ) {
-      let id = operation.properties[idKey]
-      
+      let id = operation.properties[idKey];
+
       if (
         someNode(editor, {
           match: { [idKey]: (operation.properties as Partial<TNode>)[idKey] },
         })
       ) {
         // the id in the new node is already being used in the editor, we need to replace it with a new id
-        id = idCreator()
+        id = idCreator();
       }
 
       return apply({
@@ -115,16 +115,16 @@ export const withNodeId = ({
           ...operation.properties,
           [idKey]: id,
         },
-      })
+      });
     }
 
-    return apply(operation)
-  }
+    return apply(operation);
+  };
 
-  return editor
-}
+  return editor;
+};
 
 /**
  * @see {@link withNodeId}
  */
-export const createNodeIdPlugin = getSlatePluginWithOverrides(withNodeId)
+export const createNodeIdPlugin = getSlatePluginWithOverrides(withNodeId);

--- a/packages/node-id/src/createNodeIdPlugin.ts
+++ b/packages/node-id/src/createNodeIdPlugin.ts
@@ -69,11 +69,10 @@ export const withNodeId = ({
       }
 
       const node = cloneDeep(operation.node) as TNode
-      
       // the id in the new node is already being used in the editor, we need to replace it with a new id
-      // if (someNode(editor, { match: { [idKey]: node[idKey] } })) {
-      //   node[idKey] = idCreator()
-      // }
+      if (someNode(editor, { match: { [idKey]: node[idKey] } })) {
+        delete node[idKey]
+      }
 
       // it will not overwrite ids once it's set as it's read-only
       const applyDeepToNodes = resetExistingID

--- a/stories/marks/basic-marks.stories.tsx
+++ b/stories/marks/basic-marks.stories.tsx
@@ -16,10 +16,7 @@ import {
   HeadingToolbar,
   SlatePlugins,
 } from '@udecode/slate-plugins';
-import {
-  initialValueBasicMarks,
-  initialValueMarks,
-} from '../config/initialValues';
+import { initialValueMarks } from '../config/initialValues';
 import { editableProps } from '../config/pluginOptions';
 import { ToolbarButtonsBasicMarks } from '../config/Toolbars';
 


### PR DESCRIPTION
check if the operation is in the history before adding the id to the removedId Set

## Issue



## What I did



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->