### PR TITLE
Fix/list removal

### DIFF
--- a/packages/elements/list/src/getListDeleteBackward.ts
+++ b/packages/elements/list/src/getListDeleteBackward.ts
@@ -2,6 +2,7 @@ import {
   deleteFragment,
   ELEMENT_DEFAULT,
   isCollapsed,
+  isFirstChild,
   isSelectionAtBlockStart,
 } from '@udecode/slate-plugins-common';
 import { getSlatePluginType, SPEditor } from '@udecode/slate-plugins-core';
@@ -9,6 +10,7 @@ import { getResetNodeOnKeyDown } from '@udecode/slate-plugins-reset-node';
 import { Editor } from 'slate';
 import { getListItemEntry } from './queries/getListItemEntry';
 import { hasListChild } from './queries/hasListChild';
+import { isListNested } from './queries/isListNested';
 import { removeFirstListItem } from './transforms/removeFirstListItem';
 import { removeListItem } from './transforms/removeListItem';
 import { unwrapList } from './transforms/unwrapList';
@@ -40,8 +42,7 @@ export const getListDeleteBackward = (
           });
         }
 
-        moved = true;
-
+        moved = !isFirstChild(listItem[1]) || isListNested(editor, list[1]);
         // moved = moveListItemUp(editor, { list, listItem });
       });
 

--- a/packages/elements/list/src/transforms/removeFirstListItem.ts
+++ b/packages/elements/list/src/transforms/removeFirstListItem.ts
@@ -20,7 +20,7 @@ export const removeFirstListItem = (
   const [, listPath] = list;
   const [, listItemPath] = listItem;
 
-  if (!isListNested(editor, listPath) && isFirstChild(listItemPath)) {
+  if (!isListNested(editor, listPath) && !isFirstChild(listItemPath)) {
     moveListItemUp(editor, { list, listItem });
 
     return true;

--- a/packages/elements/list/src/transforms/unwrapList.ts
+++ b/packages/elements/list/src/transforms/unwrapList.ts
@@ -1,6 +1,6 @@
 import { unwrapNodes } from '@udecode/slate-plugins-common';
 import { getSlatePluginType, SPEditor } from '@udecode/slate-plugins-core';
-import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '../defaults';
+import { ELEMENT_LI, ELEMENT_LIC, ELEMENT_OL, ELEMENT_UL } from '../defaults';
 
 export const unwrapList = (editor: SPEditor) => {
   unwrapNodes(editor, {
@@ -14,5 +14,8 @@ export const unwrapList = (editor: SPEditor) => {
       ],
     },
     split: true,
+  });
+  unwrapNodes(editor, {
+    match: { type: getSlatePluginType(editor, ELEMENT_LIC) },
   });
 };


### PR DESCRIPTION
**Description**

Solves issue where deleting the first list item of a non-nested list causes the lic element to be default element (see #667).

**Issue**

Fixes: #667

**Example**

Before (we're left with a lic element):
![before](https://user-images.githubusercontent.com/25618095/116981608-0a3ae280-acc8-11eb-9c76-44664e74791c.gif)

After (correctly reset to default element):
![after](https://user-images.githubusercontent.com/25618095/116981633-16bf3b00-acc8-11eb-8482-1004b9c8ac99.gif)


**Context**

To be honest I only know this fixes my issue. I'm not sure if these changes will break any other functionality.
- First thing I did was patch a bug in the `removeFirstListItem` function
- Then only set moved to true if we're not the first element of a non-nested list (because thats when we need unwrapping & resetting)
- Then made sure the `lic` element is also unwrapped, otherwise we end up with the default element still wrapped in a `lic` element.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn
      storybook`.)
- [ ] You've
      [added a changeset](https://github.com/atlassian/changesets/blob/main/docs/adding-a-changeset.md)
      if changing functionality. (Add one with `yarn changeset add`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
