### PR TITLE
call user supplied onChange with editor

### DIFF
--- a/packages/core/src/hooks/useSlatePlugins/useSlateProps.ts
+++ b/packages/core/src/hooks/useSlatePlugins/useSlateProps.ts
@@ -32,7 +32,7 @@ export const useSlateProps = ({
 
         editor && pipeOnChange(editor, plugins)(newValue);
 
-        _onChange?.(newValue);
+        _onChange?.(newValue, editor);
       },
       value,
     }),

--- a/packages/core/src/types/UseSlatePropsOptions.ts
+++ b/packages/core/src/types/UseSlatePropsOptions.ts
@@ -1,3 +1,4 @@
+import { SPEditor } from './SPEditor';
 import { TNode } from './TNode';
 import { UseSlatePluginsEffectsOptions } from './UseSlatePluginsEffectsOptions';
 
@@ -9,5 +10,5 @@ export interface UseSlatePropsOptions
   /**
    * Controlled callback called when the editor state changes.
    */
-  onChange?: (value: TNode[]) => void;
+  onChange?: (value: TNode[], editor: SPEditor | undefined) => void;
 }

--- a/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
+++ b/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
@@ -17,7 +17,7 @@ const trimWhitespace = (rawHtml: string): string =>
 // Remove redundant data attributes
 const stripSlateDataAttributes = (rawHtml: string): string =>
   rawHtml
-    .replace(/( data-slate)(-node|-type)="[^"]+"/gm, '')
+    .replace(/( data-slate)(-node|-type|-leaf)="[^"]+"/gm, '')
     .replace(/( data-testid)="[^"]+"/gm, '');
 
 /**


### PR DESCRIPTION
**Description**

- Calls the `onChange` callback with the newly created editor
- Include `data-slate-leaf` in attributes that are optionally stripped on serialization

**Issue**

If you need to use the `editor` instance in your custom `onChange`, you'd need to create it manually and pass to `<SlatePlugins>` as a prop instead of letting slate plugins create it in the default manner.  Separately, serialization of leaf nodes leaves new `data-slate-leaf` attributes in the output.

**Example**

```
import { config } from 'lib/slate' // includes plugins, options, components, etc

const Editor = () => {
  const onChange = (newValue, editor) => {
    serializeHTMLFromNodes(editor, { plugins: config.plugins, nodes: newValue }) // in reality this function is debounced
  }

  return <SlatePlugins {...{...config, onChange }} />
}
```

**Context**

After upgrading to the latest from v0.75, `serializeHTMLFromNodes` now takes the `editor` as its first argument.  Since I want to serialize slate with the `onChange` handler, but would prefer to let `SlatePlugins` create / manage the editor, it would be beneficial to get an instance of the editor back to solve this chicken and egg scenario.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn
      storybook`.)
- [ ] You've
      [added a changeset](https://github.com/atlassian/changesets/blob/main/docs/adding-a-changeset.md)
      if changing functionality. (Add one with `yarn changeset add`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
