### PR TITLE
[Mention plugin] expose setValueIndex for select

### DIFF
--- a/.changeset/polite-goats-watch.md
+++ b/.changeset/polite-goats-watch.md
@@ -2,4 +2,4 @@
 "@udecode/slate-plugins-mention": patch
 ---
 
-add `setValueIndex` to the returned object of `useMentionPlugin`
+add `setValueIndex` to `useMentionPlugin().getMentionSelectProps()`

--- a/.changeset/polite-goats-watch.md
+++ b/.changeset/polite-goats-watch.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-mention": patch
+---
+
+add `setValueIndex` to the returned object of `useMentionPlugin`

--- a/packages/elements/mention/src/useMentionPlugin.ts
+++ b/packages/elements/mention/src/useMentionPlugin.ts
@@ -147,6 +147,7 @@ export const useMentionPlugin = ({
       () => ({
         at: targetRange,
         valueIndex,
+        setValueIndex,
         options: values,
         onClickMention: onAddMention,
       }),


### PR DESCRIPTION
**Description**

I need to highlight an active option. An option should become active when you navigate to it using keyboard or mouse.

**Issue**
Currently mention-plugin changes `valueIndex` only on keyboard navigation. It would be useful to change it `onMouseEnter` as well. For this purpose the `setValueIndex` need to be exposed.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn
      storybook`.)
- [x] You've
      [added a changeset](https://github.com/atlassian/changesets/blob/main/docs/adding-a-changeset.md)
      if changing functionality. (Add one with `yarn changeset add`.)
