### PR TITLE
fix: strip new data-slate-leaf attributes

### DIFF
--- a/.changeset/violet-bees-deliver.md
+++ b/.changeset/violet-bees-deliver.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-html-serializer": patch
+---
+
+fix: strip data-slate-leaf from serialized html

--- a/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
+++ b/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
@@ -17,7 +17,7 @@ const trimWhitespace = (rawHtml: string): string =>
 // Remove redundant data attributes
 const stripSlateDataAttributes = (rawHtml: string): string =>
   rawHtml
-    .replace(/( data-slate)(-node|-type)="[^"]+"/gm, '')
+    .replace(/( data-slate)(-node|-type|-leaf)="[^"]+"/gm, '')
     .replace(/( data-testid)="[^"]+"/gm, '');
 
 /**


### PR DESCRIPTION
**Description**

slate introduced a new data attribute `data-slate-leaf` that doesn't get stripped out in `serializeHtmlFromNodes`

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
