### PR TITLE
fix missing placeholder alias in doc config

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -272,6 +272,10 @@ module.exports = {
             __dirname,
             '../packages/elements/paragraph/src'
           ),
+          '@udecode/slate-plugins-placeholder': path.resolve(
+            __dirname,
+            '../packages/placeholder/src'
+          ),
           '@udecode/slate-plugins-table': path.resolve(
             __dirname,
             '../packages/elements/table/src'


### PR DESCRIPTION
Fix the following error when  running `yarn start` :
```
../packages/slate-plugins/src/index.tsx
Module not found: Can't resolve '@udecode/slate-plugins-placeholder' in '/home/jim/rien/slate-plugins/packages/slate-plugins/src'
```
