### PR TITLE
feat: supporting "getLinkUrl" for "ToolbarLink"

### DIFF
--- a/.changeset/polite-cars-tie.md
+++ b/.changeset/polite-cars-tie.md
@@ -1,6 +1,5 @@
 ---
 "@udecode/slate-plugins-link-ui": patch
-"@udecode/slate-plugins-link": patch
 ---
 
-feat: supporting "getLinkUrl" for "ToolbarLink"
+feat: new option `getLinkUrl` for `ToolbarLink` (default: `window.prompt`)

--- a/.changeset/polite-cars-tie.md
+++ b/.changeset/polite-cars-tie.md
@@ -1,0 +1,6 @@
+---
+"@udecode/slate-plugins-link-ui": patch
+"@udecode/slate-plugins-link": patch
+---
+
+feat: supporting "getLinkUrl" for "ToolbarLink"


### PR DESCRIPTION
**Description**

Supporting "getLinkUrl" for "ToolbarLink". So we can customize input component.（Like ”getLinkUrl“ in ”ToolbarImage")

**Example**

```ts
import {ToolbarLink} from "@udecode/slate-plugins";

function getLinkUrl(prev: string | null): Promise<string | null> {}

<ToolbarLink getLinkUrl={getLinkUrl} />
```

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
