### PR TITLE
Fix deserialization of italic plugin

### DIFF
--- a/.changeset/tasty-wasps-explain.md
+++ b/.changeset/tasty-wasps-explain.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-basic-marks": patch
+---
+
+fix: deserialization of italic plugin

--- a/packages/marks/basic-marks/src/italic/createItalicPlugin.ts
+++ b/packages/marks/basic-marks/src/italic/createItalicPlugin.ts
@@ -1,6 +1,6 @@
 import { getToggleMarkOnKeyDown } from '@udecode/slate-plugins-common';
 import { getRenderLeaf, SlatePlugin } from '@udecode/slate-plugins-core';
-import { getCodeDeserialize } from '../code/getCodeDeserialize';
+import { getItalicDeserialize } from './getItalicDeserialize';
 import { MARK_ITALIC } from './defaults';
 
 /**
@@ -9,6 +9,6 @@ import { MARK_ITALIC } from './defaults';
 export const createItalicPlugin = (): SlatePlugin => ({
   pluginKeys: MARK_ITALIC,
   renderLeaf: getRenderLeaf(MARK_ITALIC),
-  deserialize: getCodeDeserialize(),
+  deserialize: getItalicDeserialize(),
   onKeyDown: getToggleMarkOnKeyDown(MARK_ITALIC),
 });


### PR DESCRIPTION
Italic plugin uses Code plugin's deserializer by mistake. I fixed it.