### PR TITLE
Add normalization for 3rd constraint

### DIFF
--- a/.changeset/blue-eels-mate.md
+++ b/.changeset/blue-eels-mate.md
@@ -1,0 +1,9 @@
+---
+"@udecode/slate-plugins-common": major
+"@udecode/slate-plugins-html-serializer": patch
+---
+
+changes:
+- BREAKING CHANGE: `normalizeDescendantsToDocumentFragment` parameters are now: `(editor, { descendants })`. Used by the HTML deserializer.
+- fix: Handles 1st constraint: "All Element nodes must contain at least one Text descendant."
+- fix: Handles 3rd constraint: "Block nodes can only contain other blocks, or inline and text nodes."

--- a/packages/common/src/__tests__/utils/normalizeDescendantsToDocumentFragment/default.spec.tsx
+++ b/packages/common/src/__tests__/utils/normalizeDescendantsToDocumentFragment/default.spec.tsx
@@ -1,16 +1,20 @@
 /** @jsx jsx */
+import { createEditorPlugins } from '@udecode/slate-plugins/src';
+import { createLinkPlugin } from '@udecode/slate-plugins-link';
 import { jsx } from '@udecode/slate-plugins-test-utils';
 import { normalizeDescendantsToDocumentFragment } from '../../../utils';
 
 jsx;
 
-const jsxEmptyTextNode = [''];
-
 describe('normalizeDescendantsToDocumentFragment()', () => {
   it.each([
     {
       input: [<hp />],
-      output: [<hp>{jsxEmptyTextNode}</hp>],
+      output: [
+        <hp>
+          <htext />
+        </hp>,
+      ],
     },
     {
       input: [
@@ -20,14 +24,89 @@ describe('normalizeDescendantsToDocumentFragment()', () => {
       ],
       output: [
         <hp>
-          <hp>{jsxEmptyTextNode}</hp>
+          <hp>
+            <htext />
+          </hp>
         </hp>,
       ],
     },
   ])(
     'should add a blank leaf to blocks without children',
     ({ input, output }: any) => {
-      expect(normalizeDescendantsToDocumentFragment(input)).toEqual(output);
+      const editor = createEditorPlugins();
+      const result = normalizeDescendantsToDocumentFragment(editor, {
+        descendants: input,
+      });
+      expect(result).toEqual(output);
+    }
+  );
+
+  it.each([
+    {
+      input: [<htext>text node</htext>, <htext>another text node</htext>],
+      output: [<htext>text node</htext>, <htext>another text node</htext>],
+    },
+    {
+      input: [<ha>inline element</ha>, <htext>text node</htext>],
+      output: [<ha>inline element</ha>, <htext>text node</htext>],
+    },
+    {
+      input: [<hp>block</hp>, <hp>another block</hp>, <htext>text node</htext>],
+      output: [<hp>block</hp>, <hp>another block</hp>, <hp>text node</hp>],
+    },
+    {
+      input: [<ha>inline element</ha>, <hp>block</hp>],
+      output: [
+        <hp>
+          <ha>inline element</ha>
+        </hp>,
+        <hp>block</hp>,
+      ],
+    },
+    {
+      input: [
+        <htext>text 1</htext>,
+        <htext>text 2</htext>,
+        <hp>block</hp>,
+        <htext>text 3</htext>,
+        <htext>text 4</htext>,
+      ],
+      output: [
+        <hp>
+          <htext>text 1</htext>
+          <htext>text 2</htext>
+        </hp>,
+        <hp>block</hp>,
+        <hp>
+          <htext>text 3</htext>
+          <htext>text 4</htext>
+        </hp>,
+      ],
+    },
+    {
+      input: [
+        <hp>
+          <htext>text node</htext>
+          <hp>block</hp>
+        </hp>,
+      ],
+      output: [
+        <hp>
+          <hp>text node</hp>
+          <hp>block</hp>
+        </hp>,
+      ],
+    },
+  ])(
+    'should wrap inline blocks and text nodes in case they have a sibling block',
+    ({ input, output }: any) => {
+      const editor = createEditorPlugins({
+        plugins: [createLinkPlugin()],
+      });
+      const result = normalizeDescendantsToDocumentFragment(editor, {
+        descendants: input,
+      });
+      expect(result).toEqual(output);
     }
   );
 });

--- a/packages/common/src/__tests__/utils/normalizeDescendantsToDocumentFragment/default.spec.tsx
+++ b/packages/common/src/__tests__/utils/normalizeDescendantsToDocumentFragment/default.spec.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { jsx } from '@udecode/slate-plugins-test-utils';
+import { normalizeDescendantsToDocumentFragment } from '../../../utils';
+
+jsx;
+
+const jsxEmptyTextNode = [''];
+
+describe('normalizeDescendantsToDocumentFragment()', () => {
+  it.each([
+    {
+      input: [<hp />],
+      output: [<hp>{jsxEmptyTextNode}</hp>],
+    },
+    {
+      input: [
+        <hp>
+          <hp />
+        </hp>,
+      ],
+      output: [
+        <hp>
+          <hp>{jsxEmptyTextNode}</hp>
+        </hp>,
+      ],
+    },
+  ])(
+    'should add a blank leaf to blocks without children',
+    ({ input, output }: any) => {
+      expect(normalizeDescendantsToDocumentFragment(input)).toEqual(output);
+    }
+  );
+});

--- a/packages/common/src/utils/normalizeDescendantsToDocumentFragment.ts
+++ b/packages/common/src/utils/normalizeDescendantsToDocumentFragment.ts
@@ -1,20 +1,116 @@
-import { isElement, TDescendant } from '@udecode/slate-plugins-core';
+import {
+  getSlatePluginType,
+  isElement,
+  SPEditor,
+  TElement,
+} from '@udecode/slate-plugins-core';
+import { Descendant, Editor, Element, Text } from 'slate';
+import { ELEMENT_DEFAULT } from '../types';
+
+const isInlineNode = (editor: Pick<Editor, 'isInline'>) => (node: Descendant) =>
+  Text.isText(node) || editor.isInline(node);
+
+const makeBlockLazy = (type: string) => (): TElement => ({
+  type,
+  children: [],
+});
+
+const hasDifferentChildNodes = (
+  descendants: Descendant[],
+  isInline: (node: Descendant) => boolean
+): boolean => {
+  return descendants.some((descendant, index, arr) => {
+    const prevDescendant = arr[index - 1];
+    if (index !== 0) {
+      return isInline(descendant) !== isInline(prevDescendant);
+    }
+    return false;
+  });
+};
+
+/**
+ * Handles 3rd constraint: "Block nodes can only contain other blocks, or inline and text nodes."
+ */
+const normalizeDifferentNodeTypes = (
+  descendants: Descendant[],
+  isInline: (node: Descendant) => boolean,
+  makeDefaultBlock: () => Element
+): Descendant[] => {
+  const hasDifferentNodes = hasDifferentChildNodes(descendants, isInline);
+
+  const { fragment } = descendants.reduce(
+    (memo, node) => {
+      if (hasDifferentNodes && isInline(node)) {
+        let block = memo.precedingBlock;
+        if (!block) {
+          block = makeDefaultBlock();
+          memo.precedingBlock = block;
+          memo.fragment.push(block);
+        }
+        block.children.push(node);
+      } else {
+        memo.fragment.push(node);
+        memo.precedingBlock = null;
+      }
+
+      return memo;
+    },
+    {
+      fragment: [] as Descendant[],
+      precedingBlock: null as Element | null,
+    }
+  );
+
+  return fragment;
+};
+
+/**
+ * Handles 1st constraint: "All Element nodes must contain at least one Text descendant."
+ */
+const normalizeEmptyChildren = (descendants: Descendant[]): Descendant[] => {
+  if (!descendants.length) {
+    return [{ text: '' }];
+  }
+  return descendants;
+};
+
+const normalize = (
+  descendants: Descendant[],
+  isInline: (node: Descendant) => boolean,
+  makeDefaultBlock: () => Element
+) => {
+  descendants = normalizeEmptyChildren(descendants);
+  descendants = normalizeDifferentNodeTypes(
+    descendants,
+    isInline,
+    makeDefaultBlock
+  );
+
+  descendants = descendants.map((node) => {
+    if (isElement(node)) {
+      return {
+        ...node,
+        children: normalize(node.children, isInline, makeDefaultBlock),
+      };
+    }
+    return node;
+  });
+
+  return descendants;
+};
 
 /**
  * Normalize the descendants to a valid document fragment.
  */
-export const normalizeDescendantsToDocumentFragment = (
-  descendants: TDescendant[]
+export const normalizeDescendantsToDocumentFragment = <
+  T extends SPEditor = SPEditor
+>(
+  editor: T,
+  { descendants }: { descendants: Descendant[] }
 ) => {
-  descendants.forEach((element) => {
-    if (isElement(element)) {
-      normalizeDescendantsToDocumentFragment(element.children);
-    }
-  });
+  const isInline = isInlineNode(editor);
+  const defaultType = getSlatePluginType(editor, ELEMENT_DEFAULT);
+  const makeDefaultBlock = makeBlockLazy(defaultType);
 
-  if (!descendants.length) {
-    descendants.push({ text: '' });
-  }
-
-  return descendants;
+  return normalize(descendants, isInline, makeDefaultBlock);
 };

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/withDeserializeHTML/html.spec.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
-
 import { SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
+import { createParagraphPlugin } from '@udecode/slate-plugins-paragraph';
 import { jsx } from '@udecode/slate-plugins-test-utils';
 import { Editor } from 'slate';
 import { ReactEditor } from 'slate-react';
@@ -13,6 +13,12 @@ jsx;
 // noinspection CheckTagEmptyBody
 const data = {
   getData: () => '<html><body><h1>inserted</h1></body></html>',
+};
+
+const makeDataTransfer = (value: string): DataTransfer => {
+  return {
+    getData: () => value,
+  } as any;
 };
 
 describe('when inserting html', () => {
@@ -83,5 +89,45 @@ describe('when inserting html', () => {
 
       expect(editor.children).toEqual(expected.children);
     });
+  });
+
+  describe('when inserting a text node surrounded by elements', () => {
+    const input = ((
+      <editor>
+        <hp>
+          <cursor />
+        </hp>
+      </editor>
+    ) as any) as Editor;
+
+    const expected = (
+      <editor>
+        <hp>first element</hp>
+        <hp>second element</hp>
+        <hp>
+          text node in the end
+          <cursor />
+        </hp>
+      </editor>
+    ) as any;
+
+    const plugins: SlatePlugin<ReactEditor & SPEditor>[] = [
+      createParagraphPlugin(),
+    ];
+
+    plugins.push(createDeserializeHTMLPlugin({ plugins }));
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins,
+    });
+
+    editor.insertData(
+      makeDataTransfer(
+        '<html><body><p>first element</p><p>second element</p>text node in the end</body></html>'
+      )
+    );
+
+    expect(editor.children).toEqual(expected.children);
   });
 });

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
@@ -31,5 +31,7 @@ export const deserializeHTMLToDocumentFragment = <
     element,
   }) as TDescendant[];
 
-  return normalizeDescendantsToDocumentFragment(fragment);
+  return normalizeDescendantsToDocumentFragment(editor, {
+    descendants: fragment,
+  });
 };


### PR DESCRIPTION
**Description**

Additionally to the handler of the first constraint (https://docs.slatejs.org/concepts/11-normalizing) I added a handler for 3rd one. The original problem was pasting HTML text that does not follow these rules. Say we have copied text that has such source:
```html
<p>Some text</p>
<p>Another paragraph text</p>
<a>Any inline element</a>
``` 
When we paste it to the editor it becomes:
```html
<p>Some text<a>Any inline element</a></p>
<p>Another paragraph text</p>
```
Personally I treat it as a bug, since Google Doc and Apple Notes paste it in original order. So my fix wraps such elements with a default block, like so:
```html
<p>Some text</p>
<p>Another paragraph text</p>
<p><a>Any inline element</a></p>
``` 

The PR mainly touches `normalizeDescendantsToDocumentFragment()`. I changed its interface, I don't if this function is a part of public API. In any case I added "Breaking Change" label.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
