### PR TITLE
Fix calling leaf serializers with preceding serialization result

### DIFF
--- a/.changeset/cold-lemons-taste.md
+++ b/.changeset/cold-lemons-taste.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-html-serializer": patch
+---
+
+fix: calling leaf serializers with preceding serialization result

--- a/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
+++ b/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
@@ -135,7 +135,7 @@ const getLeaf = (
         createElementWithSlate({
           ...slateProps,
           children:
-            plugin.serialize?.leaf?.(leafProps) ??
+            plugin.serialize?.leaf?.(newLeafProps) ??
             plugin.renderLeaf?.(editor)(newLeafProps),
         })
       )


### PR DESCRIPTION
**Description**

Source problem is adding a leaf serializer ignores all previous serialization of that leaf. However similar `renderLeaf` plugin option works differently. It feeds preceding computation of `renderLeaf` to succeeding, so it looks like a cascade. I've made changes that serialization works in the same way.

**Example**

https://codesandbox.io/s/slate-plugins-playground-v1-forked-4146s?file=/index.tsx:0-54

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
