### PR TITLE
fix - improve list-item-container normalization

### DIFF
--- a/.changeset/many-birds-flow.md
+++ b/.changeset/many-birds-flow.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-list": patch
+---
+
+fix - improve list-item-container normalization


### PR DESCRIPTION
**Description**

List-item-container normalization was always adding an lic, even if legacy code had a paragraph element. This replaces the direct descendant p with an lic rather than further nesting, and attempts to correct if someone upgraded from 0.75 or earlier of slate-plugins to 1.0.

**Issue**

Fixes behavior of list-item-container normalization

**Example**

For the most part things look and behave the same to a user, but it fixes normalization errors when migrating from pre 1.0 slate-plugins.



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
