### PR TITLE
List item container normalization

### DIFF
--- a/.changeset/many-birds-flow.md
+++ b/.changeset/many-birds-flow.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-list": patch
+---
+
+fix - improve list-item-container normalization

--- a/.changeset/many-birds-flow.md
+++ b/.changeset/many-birds-flow.md
@@ -2,4 +2,4 @@
 "@udecode/slate-plugins-list": patch
 ---
 
-fix - improve list-item-container normalization
+fix - improve lic (list-item-content) normalization

--- a/.changeset/many-birds-flow.md
+++ b/.changeset/many-birds-flow.md
@@ -2,4 +2,4 @@
 "@udecode/slate-plugins-list": patch
 ---
 
-fix - improve lic (list-item-content) normalization
+fix: improve lic (list-item-content) normalization

--- a/packages/elements/list/src/normalizers/getListNormalizer.ts
+++ b/packages/elements/list/src/normalizers/getListNormalizer.ts
@@ -31,7 +31,7 @@ export const getListNormalizer = (
     if (node.type === getSlatePluginType(editor, ELEMENT_LI)) {
       if (
         normalizeListItem(editor, {
-          nodeEntry: [node, path],
+          listItem: [node, path],
           validLiChildrenTypes,
         })
       ) {

--- a/packages/elements/list/src/normalizers/normalizeListItem.ts
+++ b/packages/elements/list/src/normalizers/normalizeListItem.ts
@@ -57,6 +57,7 @@ export const normalizeListItem = (
       type: getSlatePluginType(editor, ELEMENT_LIC),
     });
   }
+
   if (firstChild.type !== getSlatePluginType(editor, ELEMENT_LIC)) {
     insertEmptyElement(editor, getSlatePluginType(editor, ELEMENT_LIC), {
       at: firstChildPath,

--- a/packages/elements/list/src/withList.spec.tsx
+++ b/packages/elements/list/src/withList.spec.tsx
@@ -10,8 +10,8 @@ import { createListPlugin } from './createListPlugin';
 jsx;
 
 describe('normalizeList', () => {
-  describe('when there is no p in li', () => {
-    it('should insert a p', () => {
+  describe('when there is no lic in li', () => {
+    it('should insert lic', () => {
       const input = ((
         <editor>
           <hul>
@@ -180,10 +180,7 @@ describe('normalizeList', () => {
                   </hp>
                 </element>
                 <element>
-                  <hp>
-                    world
-                    <cursor />
-                  </hp>
+                  <hp> world</hp>
                 </element>
               </hlic>
             </hli>

--- a/packages/elements/list/src/withList.spec.tsx
+++ b/packages/elements/list/src/withList.spec.tsx
@@ -166,8 +166,8 @@ describe('normalizeList', () => {
     });
   });
 
-  describe('when li > lic > block > block > children', () => {
-    it('should be li > lic > children', () => {
+  describe('when li > lic > many block > block > children', () => {
+    it('should be li > lic > children merged', () => {
       const input = ((
         <editor>
           <hul>

--- a/packages/elements/list/src/withList.spec.tsx
+++ b/packages/elements/list/src/withList.spec.tsx
@@ -51,4 +51,164 @@ describe('normalizeList', () => {
       expect(editor.children).toEqual(expected.children);
     });
   });
+
+  describe('when li > p > children', () => {
+    it('should set p to lic', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hp>
+                hell
+                <cursor />
+              </hp>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>hello</hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const editor = createEditorPlugins({
+        editor: input,
+        plugins: [createParagraphPlugin(), createListPlugin()],
+      });
+
+      editor.insertText('o');
+
+      expect(editor.children).toEqual(expected.children);
+    });
+  });
+
+  describe('when li > lic > p > children', () => {
+    it('should be li > lic > children', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                <hp>
+                  hell
+                  <cursor />
+                </hp>
+              </hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>hello</hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const editor = createEditorPlugins({
+        editor: input,
+        plugins: [createParagraphPlugin(), createListPlugin()],
+      });
+
+      editor.insertText('o');
+
+      expect(editor.children).toEqual(expected.children);
+    });
+  });
+
+  describe('when li > lic > block > block > children', () => {
+    it('should be li > lic > children', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                <element>
+                  <hp>
+                    hell
+                    <cursor />
+                  </hp>
+                </element>
+              </hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>hello</hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const editor = createEditorPlugins({
+        editor: input,
+        plugins: [createParagraphPlugin(), createListPlugin()],
+      });
+
+      editor.insertText('o');
+
+      expect(editor.children).toEqual(expected.children);
+    });
+  });
+
+  describe('when li > lic > block > block > children', () => {
+    it('should be li > lic > children', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                <element>
+                  <hp>
+                    hell
+                    <cursor />
+                  </hp>
+                </element>
+                <element>
+                  <hp>
+                    world
+                    <cursor />
+                  </hp>
+                </element>
+              </hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>hello world</hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const editor = createEditorPlugins({
+        editor: input,
+        plugins: [createParagraphPlugin(), createListPlugin()],
+      });
+
+      editor.insertText('o');
+
+      expect(editor.children).toEqual(expected.children);
+    });
+  });
 });

--- a/packages/elements/list/src/withList.spec.tsx
+++ b/packages/elements/list/src/withList.spec.tsx
@@ -53,7 +53,7 @@ describe('normalizeList', () => {
   });
 
   describe('when li > p > children', () => {
-    it('should set p to lic', () => {
+    it('should be li > lic > children', () => {
       const input = ((
         <editor>
           <hul>


### PR DESCRIPTION
**Description**

List item normalization did not cover all scenarios, and in particular did not completely handle the change from using the default type (usually a paragraph) to a list item container.

**Issue**

Fixes scenarios and upgrades that would generate invalid list nesting

**Example**

It was pretty easy to end up with list item > list item container > paragraph > children rather than list item > list item container > children.

**Context**

New logic handles a variety of possible list normalization scenarios.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
