### PR TITLE
prevent excalidraw from stealing focus

### DIFF
--- a/.changeset/good-hornets-crash.md
+++ b/.changeset/good-hornets-crash.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-excalidraw": minor
+---
+
+fix: prevent excalidraw from stealing scroll/focus

--- a/packages/elements/excalidraw/src/components/ExcalidrawElement/ExcalidrawElement.tsx
+++ b/packages/elements/excalidraw/src/components/ExcalidrawElement/ExcalidrawElement.tsx
@@ -10,7 +10,7 @@ export const ExcalidrawElement = ({
   nodeProps,
   element,
   styles: _styles,
-  scrollToContent = false,
+  scrollToContent = true,
   libraryItems = [],
   excalidrawProps: _excalidrawProps,
 }: ExcalidrawElementProps) => {

--- a/packages/elements/excalidraw/src/components/ExcalidrawElement/ExcalidrawElement.tsx
+++ b/packages/elements/excalidraw/src/components/ExcalidrawElement/ExcalidrawElement.tsx
@@ -10,7 +10,7 @@ export const ExcalidrawElement = ({
   nodeProps,
   element,
   styles: _styles,
-  scrollToContent = true,
+  scrollToContent = false,
   libraryItems = [],
   excalidrawProps: _excalidrawProps,
 }: ExcalidrawElementProps) => {
@@ -34,6 +34,7 @@ export const ExcalidrawElement = ({
       scrollToContent,
       libraryItems,
     },
+    detectScroll: false,
     // onChange: (elements: readonly ExcalidrawElementType[], state: AppState) => {
     // const path = ReactEditor.findPath(editor, element);
 


### PR DESCRIPTION
**Description**

Excalidraw plugin was stealing focus/scroll onmount

**Issue**

Excalidraw no longer steals focus (though I do see a single frame flicker of the component)

**Example**

In the playground, when loading the page, it was scrolling to have Excalidraw in focus. With this change, there is a brief flicker but the scroll position does not change.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
