### PR TITLE
Add 'What it does' line to Utils doc pages.

### DIFF
--- a/docs/docs/plugins/autoformat.mdx
+++ b/docs/docs/plugins/autoformat.mdx
@@ -3,6 +3,9 @@ slug: /plugins/autoformat
 title: Autoformat
 ---
 
+Allows you to apply formatting based on character sequences, such as automatically converting `# `
+into an H1.
+
 ### `createAutoformatPlugin`
 
 ```ts live

--- a/docs/docs/plugins/exit-break.mdx
+++ b/docs/docs/plugins/exit-break.mdx
@@ -3,6 +3,8 @@ slug: /plugins/exit-break
 title: Exit Break
 ---
 
+Allows you to create hotkeys which exit the current block.
+
 ### `createExitBreakPlugin`
 
 ```ts live

--- a/docs/docs/plugins/forced-layout.mdx
+++ b/docs/docs/plugins/forced-layout.mdx
@@ -3,6 +3,8 @@ slug: /plugins/forced-layout
 title: Forced Layout
 ---
 
+Allows you to enforce document structure. For example, you can require that the first line is an H1.
+
 - `createNormalizeTypesPlugin`
 - `createTrailingBlockPlugin`
 

--- a/docs/docs/plugins/reset-node.mdx
+++ b/docs/docs/plugins/reset-node.mdx
@@ -5,7 +5,7 @@ title: Reset Node
 
 ### `createResetNodePlugin`
 
-Enables support for resetting block type from rules.
+Allows you to reset the block type based on certain rules.
 
 In the following example, you can press `Enter` in an empty block quote or `Backspace` at the start of a block so it resets to a paragraph.
 

--- a/docs/docs/plugins/soft-break.mdx
+++ b/docs/docs/plugins/soft-break.mdx
@@ -5,6 +5,8 @@ title: Soft Break
 
 ### `createSoftBreakPlugin`
 
+Allows you to create hotkeys which insert a line break, without exiting the current block.
+
 ```ts live
 () => {
   const optionsSoftBreakPlugin = {


### PR DESCRIPTION
**Description**

The Utils docs jump right into how to configure them, without answering the really basic question of "What does this
thing do?" This pull request adds a single line at the top, providing that answer.

**Issue**

N/A, it just tripped me up personally.

**Example**

N/A

**Context**

N/A

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

Anyway, Just want to say thanks for this project. It's a big help!