### PR TITLE
Adds multiple indenting and dedenting, list hotkeys

### DIFF
--- a/packages/elements/list/src/createListPlugin.ts
+++ b/packages/elements/list/src/createListPlugin.ts
@@ -12,6 +12,6 @@ export const createListPlugin = (options?: WithListOptions): SlatePlugin => ({
   pluginKeys: KEYS_LIST,
   renderElement: getRenderElement(KEYS_LIST),
   deserialize: getListDeserialize(),
-  onKeyDown: getListOnKeyDown(),
+  onKeyDown: getListOnKeyDown(KEYS_LIST),
   withOverrides: withList(options),
 });

--- a/packages/elements/list/src/getListOnKeyDown.ts
+++ b/packages/elements/list/src/getListOnKeyDown.ts
@@ -1,11 +1,19 @@
-import { isFirstChild } from '@udecode/slate-plugins-common';
-import { KeyboardHandler } from '@udecode/slate-plugins-core';
+import { isFirstChild, mapSlatePluginKeysToOptions } from '@udecode/slate-plugins-common';
+import { getSlatePluginTypes, SPEditor, KeyboardHandler } from '@udecode/slate-plugins-core';
+import isHotkey from 'is-hotkey';
+import { castArray } from 'lodash';
+import { Editor, Path, Transforms } from 'slate';
+
 import { getListItemEntry } from './queries/getListItemEntry';
 import { isAcrossListItems } from './queries/isAcrossListItems';
 import { moveListItemDown } from './transforms/moveListItemDown';
 import { moveListItemUp } from './transforms/moveListItemUp';
+import { ELEMENT_UL, ELEMENT_OL } from './defaults.ts';
+import { toggleList } from './transforms/toggleList.ts';
 
-export const getListOnKeyDown = (): KeyboardHandler => (editor) => (e) => {
+export const getListOnKeyDown = (pluginKeys?: string | string[]): KeyboardHandler => (editor) => (e) => {
+  const listTypes = getSlatePluginTypes([ELEMENT_UL, ELEMENT_OL])(editor);
+  const options = pluginKeys ? mapSlatePluginKeysToOptions(editor, pluginKeys) : [];
   let moved: boolean | undefined = false;
 
   if (e.key === 'Tab') {
@@ -13,7 +21,43 @@ export const getListOnKeyDown = (): KeyboardHandler => (editor) => (e) => {
     if (!res) return;
 
     // TODO: handle multiple li
-    if (isAcrossListItems(editor)) return;
+    if (isAcrossListItems(editor)) {
+      const { selection } = editor;
+      const { anchor: { path: fromPath }, focus: { path: toPath } } = selection!;
+      // this won't work if it's across multiple blocks so the method below should work
+      // find the latest common parent of the two elements
+      let counter = 0;
+      while (fromPath[counter] === toPath[counter]) {
+        counter++;
+      }
+      const pathEndpoints = [fromPath[counter], toPath[counter]]
+      pathEndpoints.sort()
+      const [startSibling, endSibling] = pathEndpoints;
+      if (e.shiftKey) {
+        const parentList = Editor.node(editor, fromPath.slice(0, counter));
+        const [parentItem, parentPath] = parentList;
+        for (let s = endSibling; s >= startSibling; s--) {
+          console.log(s);
+          let toDedentPath = fromPath.slice(0, counter).concat(s);
+          let toDedentItem = Editor.node(editor, toDedentPath);
+          // the parent list will keep changing during the loop so it's best to use its path only
+          const currentParent = Editor.node(editor, parentPath);
+          moved = moveListItemUp(editor, { list: currentParent as any, listItem: toDedentItem as any });
+          moved && e.preventDefault();
+        }
+      } else {
+        // the logic is the same because the path of the item to indent is invariant
+        let toIndentPath = fromPath.slice(0, counter).concat(startSibling);
+        let toIndentItem = Editor.node(editor, toIndentPath);
+        console.log(toIndentItem);
+        for (let s = startSibling; s <= endSibling; s++) {
+          moveListItemDown(editor, { list, listItem: (toIndentItem as any) });
+        } 
+        e.preventDefault();
+      }
+
+      return;
+    };
 
     const { list, listItem } = res;
     const [, listItemPath] = listItem;
@@ -32,5 +76,19 @@ export const getListOnKeyDown = (): KeyboardHandler => (editor) => (e) => {
     if (tab && !isFirstChild(listItemPath)) {
       moveListItemDown(editor, { list, listItem });
     }
+  } else {
+    options.forEach(({ type, hotkey }) => {
+      if (!hotkey) return;
+
+      const hotkeys = castArray(hotkey);
+
+      for (const key of hotkeys) {
+        if (isHotkey(key)(e as any) && listTypes.includes(type)) {
+          e.preventDefault();
+          toggleList(editor, { type })
+        }
+      }
+    })
+
   }
 };


### PR DESCRIPTION
**Description**

Adds multiple indents/dedents for lists and adding hotkeys to toggle lists.

**Issue**

Fixes: #552 

**Example**

**Context**

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
