### PR TITLE
Adds multiple indenting and dedenting, list hotkeys 

### DIFF
--- a/.changeset/shy-trees-swim.md
+++ b/.changeset/shy-trees-swim.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-list": patch
+---
+
+normalizer: set node with ELEMENT_LIC type to ELEMENT_DEFAULT if its parent type is not ELEMENT_LI

--- a/docs/src/live/config/initialValues.tsx
+++ b/docs/src/live/config/initialValues.tsx
@@ -524,7 +524,7 @@ export const initialValueList: any = [
     type: ELEMENT_H2,
     children: [{ text: '✍️ List' }],
   },
-  { type: ELEMENT_LIC, children: [{ text: '' }] },
+  { type: ELEMENT_PARAGRAPH, children: [{ text: '' }] },
   {
     type: ELEMENT_UL,
     children: [

--- a/packages/elements/list/src/createListPlugin.ts
+++ b/packages/elements/list/src/createListPlugin.ts
@@ -12,6 +12,6 @@ export const createListPlugin = (options?: WithListOptions): SlatePlugin => ({
   pluginKeys: KEYS_LIST,
   renderElement: getRenderElement(KEYS_LIST),
   deserialize: getListDeserialize(),
-  onKeyDown: getListOnKeyDown(),
+  onKeyDown: getListOnKeyDown(KEYS_LIST),
   withOverrides: withList(options),
 });

--- a/packages/elements/list/src/getListOnKeyDown.ts
+++ b/packages/elements/list/src/getListOnKeyDown.ts
@@ -53,8 +53,6 @@ export const getListOnKeyDown = (
       if (!listItem) return;
       const listEntry = getParent(editor, listItem[1]);
 
-      console.log({ highestLic, listItem, listEntry });
-
       if (!e.shiftKey) {
         moveListItemDown(editor, {
           list: listEntry as any,

--- a/packages/elements/list/src/getListOnKeyDown.ts
+++ b/packages/elements/list/src/getListOnKeyDown.ts
@@ -1,127 +1,89 @@
-import {
-  findNode,
-  getAbove,
-  getNode,
-  getNodes,
-  isFirstChild,
-} from '@udecode/slate-plugins-common';
+import { getNodes, getParent } from '@udecode/slate-plugins-common';
 import {
   getSlatePluginType,
   getSlatePluginTypes,
   KeyboardHandler,
   mapSlatePluginKeysToOptions,
-  TElement,
 } from '@udecode/slate-plugins-core';
 import isHotkey from 'is-hotkey';
 import { castArray } from 'lodash';
-import { Editor } from 'slate';
-import { getListItemEntry } from './queries/getListItemEntry';
-import { isAcrossListItems } from './queries/isAcrossListItems';
+import { NodeEntry, Path } from 'slate';
 import { moveListItemDown } from './transforms/moveListItemDown';
 import { moveListItemUp } from './transforms/moveListItemUp';
 import { toggleList } from './transforms/toggleList';
-import { unwrapList } from './transforms/unwrapList';
-import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from './defaults';
+import { ELEMENT_LIC, ELEMENT_OL, ELEMENT_UL } from './defaults';
 
 export const getListOnKeyDown = (
   pluginKeys?: string | string[]
 ): KeyboardHandler => (editor) => (e) => {
   const listTypes = getSlatePluginTypes([ELEMENT_UL, ELEMENT_OL])(editor);
+
+  if (e.key === 'Tab') {
+    e.preventDefault();
+
+    // Get the selected lic
+    const [...lics] = getNodes(editor, {
+      at: editor.selection!,
+      match: {
+        type: getSlatePluginType(editor, ELEMENT_LIC),
+      },
+    });
+
+    if (!lics.length) return;
+
+    const highestLics: NodeEntry[] = [];
+
+    // Filter out the nested lic, we just need to move the highest ones
+    lics.forEach((lic) => {
+      const licPath = lic[1];
+      const liPath = Path.parent(licPath);
+
+      const isAncestor = highestLics.some((highestLic) => {
+        const highestLiPath = Path.parent(highestLic[1]);
+
+        return Path.isAncestor(highestLiPath, liPath);
+      });
+      if (!isAncestor) {
+        highestLics.push(lic);
+      }
+    });
+
+    highestLics.reverse().forEach((highestLic) => {
+      const listItem = getParent(editor, highestLic[1]);
+      if (!listItem) return;
+      const listEntry = getParent(editor, listItem[1]);
+
+      console.log({ highestLic, listItem, listEntry });
+
+      if (!e.shiftKey) {
+        moveListItemDown(editor, {
+          list: listEntry as any,
+          listItem: listItem as any,
+        });
+      } else {
+        moveListItemUp(editor, {
+          list: listEntry as any,
+          listItem: listItem as any,
+        });
+      }
+    });
+
+    return;
+  }
+
   const options = pluginKeys
     ? mapSlatePluginKeysToOptions(editor, pluginKeys)
     : [];
-  let moved: boolean | undefined = false;
 
-  if (e.key === 'Tab') {
-    if (isAcrossListItems(editor)) {
-      const list = findNode<TElement>(editor, {
-        match: { type: listTypes },
-      });
+  options.forEach(({ type, hotkey }) => {
+    if (!hotkey) return;
 
-      if (!list) return;
+    const hotkeys = castArray(hotkey);
 
-      const { selection } = editor;
-      const {
-        anchor: { path: fromPath },
-        focus: { path: toPath },
-      } = selection!;
-      // this won't work if it's across multiple blocks so the method below should work
-      // find the latest common parent of the two elements
-      // const nodes = getNodes(editor, { at: selection! });
-      // console.log([...nodes]);
-
-      let counter = 0;
-      while (fromPath[counter] === toPath[counter]) {
-        counter++;
+    for (const key of hotkeys) {
+      if (isHotkey(key)(e as any) && listTypes.includes(type)) {
+        toggleList(editor, { type });
       }
-
-      const pathEndpoints = [fromPath[counter], toPath[counter]];
-      pathEndpoints.sort();
-      const [startSibling, endSibling] = pathEndpoints;
-
-      if (e.shiftKey) {
-        const parentList = Editor.node(editor, fromPath.slice(0, counter));
-        const [, parentPath] = parentList;
-
-        for (let s = endSibling; s >= startSibling; s--) {
-          const toDedentPath = fromPath.slice(0, counter).concat(s);
-          const toDedentItem = Editor.node(editor, toDedentPath);
-          // the parent list will keep changing during the loop so it's best to use its path only
-          const currentParent = Editor.node(editor, parentPath);
-
-          moved = moveListItemUp(editor, {
-            list: currentParent as any,
-            listItem: toDedentItem as any,
-          });
-          moved && e.preventDefault();
-        }
-      } else {
-        // the logic is the same because the path of the item to indent is invariant
-        const toIndentPath = fromPath.slice(0, counter).concat(startSibling);
-        const toIndentItem = Editor.node(editor, toIndentPath);
-
-        for (let s = startSibling; s <= endSibling; s++) {
-          moveListItemDown(editor, { list, listItem: toIndentItem as any });
-        }
-
-        e.preventDefault();
-      }
-
-      return;
     }
-
-    const res = getListItemEntry(editor, {});
-    if (!res) return;
-
-    const { list, listItem } = res;
-    const [, listItemPath] = listItem;
-
-    e.preventDefault();
-
-    // move up with shift+tab
-    const shiftTab = e.shiftKey;
-    if (shiftTab) {
-      moved = moveListItemUp(editor, { list, listItem });
-      if (moved) e.preventDefault();
-    }
-
-    // move down with tab
-    const tab = !e.shiftKey;
-    if (tab && !isFirstChild(listItemPath)) {
-      moveListItemDown(editor, { list, listItem });
-    }
-  } else {
-    options.forEach(({ type, hotkey }) => {
-      if (!hotkey) return;
-
-      const hotkeys = castArray(hotkey);
-
-      for (const key of hotkeys) {
-        if (isHotkey(key)(e as any) && listTypes.includes(type)) {
-          e.preventDefault();
-          toggleList(editor, { type });
-        }
-      }
-    });
-  }
+  });
 };

--- a/packages/elements/list/src/getListOnKeyDown.ts
+++ b/packages/elements/list/src/getListOnKeyDown.ts
@@ -1,11 +1,19 @@
-import { isFirstChild } from '@udecode/slate-plugins-common';
-import { KeyboardHandler } from '@udecode/slate-plugins-core';
+import { isFirstChild, mapSlatePluginKeysToOptions } from '@udecode/slate-plugins-common';
+import { getSlatePluginTypes, SPEditor, KeyboardHandler } from '@udecode/slate-plugins-core';
+import isHotkey from 'is-hotkey';
+import { castArray } from 'lodash';
+import { Editor, Path, Transforms } from 'slate';
+
 import { getListItemEntry } from './queries/getListItemEntry';
 import { isAcrossListItems } from './queries/isAcrossListItems';
 import { moveListItemDown } from './transforms/moveListItemDown';
 import { moveListItemUp } from './transforms/moveListItemUp';
+import { ELEMENT_UL, ELEMENT_OL } from './defaults.ts';
+import { toggleList } from './transforms/toggleList.ts';
 
-export const getListOnKeyDown = (): KeyboardHandler => (editor) => (e) => {
+export const getListOnKeyDown = (pluginKeys?: string | string[]): KeyboardHandler => (editor) => (e) => {
+  const listTypes = getSlatePluginTypes([ELEMENT_UL, ELEMENT_OL])(editor);
+  const options = pluginKeys ? mapSlatePluginKeysToOptions(editor, pluginKeys) : [];
   let moved: boolean | undefined = false;
 
   if (e.key === 'Tab') {
@@ -13,7 +21,43 @@ export const getListOnKeyDown = (): KeyboardHandler => (editor) => (e) => {
     if (!res) return;
 
     // TODO: handle multiple li
-    if (isAcrossListItems(editor)) return;
+    if (isAcrossListItems(editor)) {
+      const { selection } = editor;
+      const { anchor: { path: fromPath }, focus: { path: toPath } } = selection!;
+      // this won't work if it's across multiple blocks so the method below should work
+      // find the latest common parent of the two elements
+      let counter = 0;
+      while (fromPath[counter] === toPath[counter]) {
+        counter++;
+      }
+      const pathEndpoints = [fromPath[counter], toPath[counter]]
+      pathEndpoints.sort()
+      const [startSibling, endSibling] = pathEndpoints;
+      if (e.shiftKey) {
+        const parentList = Editor.node(editor, fromPath.slice(0, counter));
+        const [parentItem, parentPath] = parentList;
+        for (let s = endSibling; s >= startSibling; s--) {
+          console.log(s);
+          let toDedentPath = fromPath.slice(0, counter).concat(s);
+          let toDedentItem = Editor.node(editor, toDedentPath);
+          // the parent list will keep changing during the loop so it's best to use its path only
+          const currentParent = Editor.node(editor, parentPath);
+          moved = moveListItemUp(editor, { list: currentParent as any, listItem: toDedentItem as any });
+          moved && e.preventDefault();
+        }
+      } else {
+        // the logic is the same because the path of the item to indent is invariant
+        let toIndentPath = fromPath.slice(0, counter).concat(startSibling);
+        let toIndentItem = Editor.node(editor, toIndentPath);
+        console.log(toIndentItem);
+        for (let s = startSibling; s <= endSibling; s++) {
+          moveListItemDown(editor, { list, listItem: (toIndentItem as any) });
+        } 
+        e.preventDefault();
+      }
+
+      return;
+    };
 
     const { list, listItem } = res;
     const [, listItemPath] = listItem;
@@ -32,5 +76,19 @@ export const getListOnKeyDown = (): KeyboardHandler => (editor) => (e) => {
     if (tab && !isFirstChild(listItemPath)) {
       moveListItemDown(editor, { list, listItem });
     }
+  } else {
+    options.forEach(({ type, hotkey }) => {
+      if (!hotkey) return;
+
+      const hotkeys = castArray(hotkey);
+
+      for (const key of hotkeys) {
+        if (isHotkey(key)(e as any) && listTypes.includes(type)) {
+          e.preventDefault();
+          toggleList(editor, { type })
+        }
+      }
+    })
+
   }
 };

--- a/packages/elements/list/src/normalizers/getListNormalizer.ts
+++ b/packages/elements/list/src/normalizers/getListNormalizer.ts
@@ -1,11 +1,16 @@
-import { match } from '@udecode/slate-plugins-common';
+import {
+  ELEMENT_DEFAULT,
+  getParent,
+  match,
+  setNodes,
+} from '@udecode/slate-plugins-common';
 import {
   getSlatePluginType,
   isElement,
   SPEditor,
 } from '@udecode/slate-plugins-core';
 import { NodeEntry, Transforms } from 'slate';
-import { ELEMENT_LI } from '../defaults';
+import { ELEMENT_LI, ELEMENT_LIC } from '../defaults';
 import { getListTypes } from '../queries/getListTypes';
 import { ListNormalizerOptions } from '../types';
 import { normalizeListItem } from './normalizeListItem';
@@ -18,6 +23,9 @@ export const getListNormalizer = (
   { validLiChildrenTypes }: ListNormalizerOptions
 ) => {
   const { normalizeNode } = editor;
+  const liType = getSlatePluginType(editor, ELEMENT_LI);
+  const licType = getSlatePluginType(editor, ELEMENT_LIC);
+  const defaultType = getSlatePluginType(editor, ELEMENT_DEFAULT);
 
   return ([node, path]: NodeEntry) => {
     if (!isElement(node)) return;
@@ -35,7 +43,14 @@ export const getListNormalizer = (
           validLiChildrenTypes,
         })
       ) {
-        // Tree changed - kick off another normalization
+        return;
+      }
+    }
+
+    // LIC should have LI parent. If not, set LIC to DEFAULT type.
+    if (node.type === licType && licType !== defaultType) {
+      if (getParent(editor, path)?.[0].type !== liType) {
+        setNodes(editor, { type: defaultType }, { at: path });
         return;
       }
     }

--- a/packages/elements/list/src/normalizers/normalizeListItem.ts
+++ b/packages/elements/list/src/normalizers/normalizeListItem.ts
@@ -73,7 +73,7 @@ export const normalizeListItem = (
     .map(([, childPath]) => Editor.pathRef(editor, childPath));
 
   const firstLiChild: NodeEntry<any> | undefined = liChildren[0];
-  const [firstLiChildNode, firstLiChildPath] = firstLiChild;
+  const [firstLiChildNode, firstLiChildPath] = firstLiChild ?? [];
 
   // If li has no child or inline child, insert lic
   if (!firstLiChild || !Editor.isBlock(editor, firstLiChildNode)) {

--- a/packages/elements/list/src/queries/getListItemEntry.ts
+++ b/packages/elements/list/src/queries/getListItemEntry.ts
@@ -34,7 +34,6 @@ export const getListItemEntry = (
       getAbove<TElement>(editor, { at, match: { type: liType } }) ||
       getParent<TElement>(editor, paragraphPath);
 
-    console.log(listItem);
     if (!listItem) return;
     const [listItemNode, listItemPath] = listItem;
 

--- a/packages/elements/list/src/queries/getListItemEntry.ts
+++ b/packages/elements/list/src/queries/getListItemEntry.ts
@@ -34,6 +34,7 @@ export const getListItemEntry = (
       getAbove<TElement>(editor, { at, match: { type: liType } }) ||
       getParent<TElement>(editor, paragraphPath);
 
+    console.log(listItem);
     if (!listItem) return;
     const [listItemNode, listItemPath] = listItem;
 

--- a/packages/elements/list/src/transforms/moveListItemDown.ts
+++ b/packages/elements/list/src/transforms/moveListItemDown.ts
@@ -15,10 +15,18 @@ export const moveListItemDown = (
   const [listNode] = list;
   const [, listItemPath] = listItem;
 
+  let previousListItemPath: Path;
+
+  try {
+    previousListItemPath = Path.previous(listItemPath);
+  } catch (e) {
+    return;
+  }
+
   // Previous sibling is the new parent
   const previousSiblingItem = Editor.node(
     editor,
-    Path.previous(listItemPath)
+    previousListItemPath
   ) as NodeEntry<Ancestor>;
 
   if (previousSiblingItem) {

--- a/packages/elements/list/src/transforms/moveListItemUp.ts
+++ b/packages/elements/list/src/transforms/moveListItemUp.ts
@@ -36,7 +36,12 @@ export const moveListItemUp = (
       match: { type: getSlatePluginType(editor, ELEMENT_LI) },
     });
     if (!liParent) {
-      const toListPath = Path.next(listPath);
+      let toListPath;
+      try {
+        toListPath = Path.next(listPath);
+      } catch (err) {
+        return;
+      }
 
       const condA = hasListChild(editor, liNode);
       const condB = !isLastChild(list, liPath);
@@ -79,7 +84,7 @@ export const moveListItemUp = (
       }
 
       // Finally, unwrap the list
-      unwrapList(editor);
+      unwrapList(editor, { at: liPath.concat(0) });
 
       return true;
     }

--- a/packages/elements/list/src/transforms/unwrapList.ts
+++ b/packages/elements/list/src/transforms/unwrapList.ts
@@ -8,10 +8,19 @@ import { Path } from 'slate';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '../defaults';
 
 export const unwrapList = (editor: SPEditor, { at }: { at?: Path } = {}) => {
+  setNodes(
+    editor,
+    {
+      type: getSlatePluginType(editor, ELEMENT_DEFAULT),
+    },
+    { at }
+  );
+
   unwrapNodes(editor, {
     at,
     match: { type: getSlatePluginType(editor, ELEMENT_LI) },
   });
+
   unwrapNodes(editor, {
     at,
     match: {
@@ -21,9 +30,5 @@ export const unwrapList = (editor: SPEditor, { at }: { at?: Path } = {}) => {
       ],
     },
     split: true,
-  });
-  setNodes(editor, {
-    at,
-    type: getSlatePluginType(editor, ELEMENT_DEFAULT),
   });
 };

--- a/packages/elements/list/src/transforms/unwrapList.ts
+++ b/packages/elements/list/src/transforms/unwrapList.ts
@@ -4,13 +4,16 @@ import {
   unwrapNodes,
 } from '@udecode/slate-plugins-common';
 import { getSlatePluginType, SPEditor } from '@udecode/slate-plugins-core';
+import { Path } from 'slate';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '../defaults';
 
-export const unwrapList = (editor: SPEditor) => {
+export const unwrapList = (editor: SPEditor, { at }: { at?: Path } = {}) => {
   unwrapNodes(editor, {
+    at,
     match: { type: getSlatePluginType(editor, ELEMENT_LI) },
   });
   unwrapNodes(editor, {
+    at,
     match: {
       type: [
         getSlatePluginType(editor, ELEMENT_UL),
@@ -20,6 +23,7 @@ export const unwrapList = (editor: SPEditor) => {
     split: true,
   });
   setNodes(editor, {
+    at,
     type: getSlatePluginType(editor, ELEMENT_DEFAULT),
   });
 };


### PR DESCRIPTION
By @newageoflight

**Description**

Adds multiple indents/dedents for lists and adding hotkeys to toggle lists.

**Issue**

Fixes: #552 

**Example**

**Context**

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
