### PR TITLE
Deserialize markdown refinements

### DIFF
--- a/.changeset/clean-penguins-peel.md
+++ b/.changeset/clean-penguins-peel.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-md-serializer": patch
+---
+
+Make markdown deserializer more consistent in approach with html and ast deserializers

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -1,7 +1,10 @@
-import { setNodes } from '@udecode/slate-plugins-common';
+import { isBlockAboveEmpty, setNodes } from '@udecode/slate-plugins-common';
 import {
+  getInlineTypes,
   getSlatePluginWithOverrides,
+  SlatePlugin,
   SPEditor,
+  TDescendant,
   TElement,
   WithOverride,
 } from '@udecode/slate-plugins-core';
@@ -9,28 +12,73 @@ import { Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { deserializeMD } from './utils/deserializeMD';
 
+export interface WithDeserializeMarkdownOptions<
+  T extends SPEditor = SPEditor & ReactEditor
+> {
+  plugins?: SlatePlugin<T>[];
+  /**
+   * Function called before inserting the deserialized markdown.
+   * Default: if the block above is empty and the first fragment node type is not inline,
+   * set the selected node type to the first fragment node type.
+   */
+  preInsert?: (fragment: TDescendant[]) => TDescendant[];
+
+  /**
+   * Function called to insert the deserialized markdown.
+   * Default: Transforms.insertFragment.
+   */
+  insert?: (fragment: TDescendant[]) => void;
+}
+
 /**
  * Enables support for deserializing content
  * from Markdown format to Slate format.
  */
-export const withDeserializeMD = (): WithOverride<ReactEditor & SPEditor> => (
-  editor
-) => {
+export const withDeserializeMD = <
+  T extends ReactEditor & SPEditor = ReactEditor & SPEditor
+>({
+  plugins = [],
+  ...options
+}: WithDeserializeMarkdownOptions<T> = {}): WithOverride<T> => (editor) => {
   const { insertData } = editor;
+
+  const {
+    preInsert = (fragment) => {
+      const inlineTypes = getInlineTypes(editor, plugins);
+
+      const firstNodeType = fragment[0].type as string | undefined;
+
+      // replace the selected node type by the first block type
+      if (
+        isBlockAboveEmpty(editor) &&
+        firstNodeType &&
+        !inlineTypes.includes(firstNodeType) &&
+        fragment[0].type
+      ) {
+        setNodes<TElement>(editor, { type: fragment[0].type });
+      }
+
+      return fragment;
+    },
+
+    insert = (fragment) => {
+      Transforms.insertFragment(editor, fragment);
+    },
+  } = options;
 
   editor.insertData = (data) => {
     const content = data.getData('text/plain');
 
     if (content) {
-      const fragment = deserializeMD(editor, content);
+      let fragment = deserializeMD(editor, content);
 
       if (!fragment.length) return;
 
-      if (fragment[0].type) {
-        setNodes<TElement>(editor, { type: fragment[0].type });
-      }
+      // FIXME: Do something to make sure it gets handled as a document fragment (see html deserializer)
 
-      Transforms.insertFragment(editor, fragment);
+      fragment = preInsert(fragment);
+
+      insert(fragment);
       return;
     }
 


### PR DESCRIPTION
**Description**

Update the markdown deserializer code to be more similar to the html and ast deserializers

**Issue**

Trying to make sure paste from markdown works consistently.

**Example**

I had a few scenarios where the formatting of the first element was lost. Not sure yet if this fixes that.

**Context**

If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
