### PR TITLE
Improve logic for ast deserialize insert

### DIFF
--- a/.changeset/fair-squids-teach.md
+++ b/.changeset/fair-squids-teach.md
@@ -1,0 +1,7 @@
+---
+"@udecode/slate-plugins-ast-serializer": minor
+"@udecode/slate-plugins-html-serializer": minor
+"@udecode/slate-plugins-md-serializer": minor
+---
+
+Fix ast-deserialize insert, minor cleanup to html/md deserializer

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -54,15 +54,13 @@ export const withDeserializeAst = <
         firstNodeType &&
         !inlineTypes.includes(firstNodeType)
       ) {
-        setNodes<TElement>(editor, { type: fragment[0].type });
+        setNodes<TElement>(editor, { type: firstNodeType });
       }
 
       return fragment;
     },
 
-    insert = (fragment) => {
-      Transforms.insertNodes<TElement>(editor, fragment as any);
-    },
+    insert = (fragment) => Transforms.insertFragment(editor, fragment),
   } = options;
 
   editor.insertData = (data: DataTransfer) => {

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -54,7 +54,7 @@ export const withDeserializeHTML = <
         firstNodeType &&
         !inlineTypes.includes(firstNodeType)
       ) {
-        setNodes<TElement>(editor, { type: fragment[0].type });
+        setNodes<TElement>(editor, { type: firstNodeType });
       }
 
       return fragment;

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -55,7 +55,7 @@ export const withDeserializeMD = <
         !inlineTypes.includes(firstNodeType) &&
         fragment[0].type
       ) {
-        setNodes<TElement>(editor, { type: fragment[0].type });
+        setNodes<TElement>(editor, { type: firstNodeType });
       }
 
       return fragment;


### PR DESCRIPTION
**Description**

* Ast deserializer should have used insertFragment instead of insertNodes
* Reuse firstNodeType variable in all deserializers

**Issue**

Ast deserializer was inserting at the wrong ast level

**Example**



**Context**



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
