### PR TITLE
Deserialize override fragment root

### DIFF
--- a/.changeset/spicy-carrots-run.md
+++ b/.changeset/spicy-carrots-run.md
@@ -1,0 +1,7 @@
+---
+"@udecode/slate-plugins-ast-serializer": minor
+"@udecode/slate-plugins-html-serializer": minor
+"@udecode/slate-plugins-md-serializer": minor
+---
+
+allow override of firstNodeType for deserializers

--- a/.changeset/spicy-carrots-run.md
+++ b/.changeset/spicy-carrots-run.md
@@ -4,4 +4,4 @@
 "@udecode/slate-plugins-md-serializer": minor
 ---
 
-allow override of firstNodeType for deserializers
+allow override of fragment root for deserializers

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -28,6 +28,12 @@ export interface WithDeserializeAstOptions<
    * Default: Transforms.setNodes.
    */
   insert?: (fragment: TDescendant[]) => void;
+
+  /**
+   * Function called to get the first node type.
+   * Default: fragment[0].type.
+   */
+  getFirstNodeType?: (fragment: TDescendant[]) => string | undefined;
 }
 
 /**
@@ -43,10 +49,14 @@ export const withDeserializeAst = <
   const { insertData } = editor;
 
   const {
+    getFirstNodeType = (fragment) => {
+      return fragment[0].type as string | undefined;
+    },
+
     preInsert = (fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
-      const firstNodeType = fragment[0].type as string | undefined;
+      const firstNodeType = getFirstNodeType(fragment);
 
       // replace the selected node type by the first block type
       if (

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -30,7 +30,7 @@ export interface WithDeserializeAstOptions<
   insert?: (fragment: TDescendant[]) => void;
 
   /**
-   * Function called to get a custom fragment structure.
+   * Function called to get a custom fragment root.
    * Default: fragment.
    */
   getFragment?: (fragment: TDescendant[]) => TDescendant[];

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -30,10 +30,10 @@ export interface WithDeserializeAstOptions<
   insert?: (fragment: TDescendant[]) => void;
 
   /**
-   * Function called to get the first node type.
-   * Default: fragment[0].type.
+   * Function called to get a custom fragment structure.
+   * Default: fragment.
    */
-  getFirstNodeType?: (fragment: TDescendant[]) => string | undefined;
+  getFragment?: (fragment: TDescendant[]) => TDescendant[];
 }
 
 /**
@@ -49,14 +49,14 @@ export const withDeserializeAst = <
   const { insertData } = editor;
 
   const {
-    getFirstNodeType = (fragment) => {
-      return fragment[0].type as string | undefined;
+    getFragment = (fragment) => {
+      return fragment;
     },
 
     preInsert = (fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
-      const firstNodeType = getFirstNodeType(fragment);
+      const firstNodeType = fragment[0].type as string | undefined;
 
       // replace the selected node type by the first block type
       if (
@@ -79,7 +79,7 @@ export const withDeserializeAst = <
     if (ast) {
       const decoded = decodeURIComponent(window.atob(ast));
       let fragment = JSON.parse(decoded);
-
+      fragment = getFragment(fragment);
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -31,7 +31,7 @@ export interface WithDeserializeHTMLOptions<
   insert?: (fragment: TDescendant[]) => void;
 
   /**
-   * Function called to get a custom fragment structure.
+   * Function called to get a custom fragment root.
    * Default: fragment.
    */
   getFragment?: (fragment: TDescendant[]) => TDescendant[];

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -29,6 +29,12 @@ export interface WithDeserializeHTMLOptions<
    * Default: Transforms.insertFragment.
    */
   insert?: (fragment: TDescendant[]) => void;
+
+  /**
+   * Function called to get the first node type.
+   * Default: fragment[0].type.
+   */
+  getFirstNodeType?: (fragment: TDescendant[]) => string | undefined;
 }
 
 /**
@@ -43,10 +49,14 @@ export const withDeserializeHTML = <
   const { insertData } = editor;
 
   const {
+    getFirstNodeType = (fragment) => {
+      return fragment[0].type as string | undefined;
+    },
+
     preInsert = (fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
-      const firstNodeType = fragment[0].type as string | undefined;
+      const firstNodeType = getFirstNodeType(fragment);
 
       // replace the selected node type by the first block type
       if (

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -31,10 +31,10 @@ export interface WithDeserializeHTMLOptions<
   insert?: (fragment: TDescendant[]) => void;
 
   /**
-   * Function called to get the first node type.
-   * Default: fragment[0].type.
+   * Function called to get a custom fragment structure.
+   * Default: fragment.
    */
-  getFirstNodeType?: (fragment: TDescendant[]) => string | undefined;
+  getFragment?: (fragment: TDescendant[]) => TDescendant[];
 }
 
 /**
@@ -49,14 +49,14 @@ export const withDeserializeHTML = <
   const { insertData } = editor;
 
   const {
-    getFirstNodeType = (fragment) => {
-      return fragment[0].type as string | undefined;
+    getFragment = (fragment) => {
+      return fragment;
     },
 
     preInsert = (fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
-      const firstNodeType = getFirstNodeType(fragment);
+      const firstNodeType = fragment[0].type as string | undefined;
 
       // replace the selected node type by the first block type
       if (
@@ -85,7 +85,7 @@ export const withDeserializeHTML = <
         plugins,
         element: body,
       });
-
+      fragment = getFragment(fragment);
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -28,6 +28,12 @@ export interface WithDeserializeMarkdownOptions<
    * Default: Transforms.insertFragment.
    */
   insert?: (fragment: TDescendant[]) => void;
+
+  /**
+   * Function called to get the first node type.
+   * Default: fragment[0].type.
+   */
+  getFirstNodeType?: (fragment: TDescendant[]) => string | undefined;
 }
 
 /**
@@ -43,10 +49,14 @@ export const withDeserializeMD = <
   const { insertData } = editor;
 
   const {
+    getFirstNodeType = (fragment) => {
+      return fragment[0].type as string | undefined;
+    },
+
     preInsert = (fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
-      const firstNodeType = fragment[0].type as string | undefined;
+      const firstNodeType = getFirstNodeType(fragment);
 
       // replace the selected node type by the first block type
       if (

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -30,10 +30,10 @@ export interface WithDeserializeMarkdownOptions<
   insert?: (fragment: TDescendant[]) => void;
 
   /**
-   * Function called to get the first node type.
-   * Default: fragment[0].type.
+   * Function called to get a custom fragment structure.
+   * Default: fragment.
    */
-  getFirstNodeType?: (fragment: TDescendant[]) => string | undefined;
+  getFragment?: (fragment: TDescendant[]) => TDescendant[];
 }
 
 /**
@@ -49,14 +49,14 @@ export const withDeserializeMD = <
   const { insertData } = editor;
 
   const {
-    getFirstNodeType = (fragment) => {
-      return fragment[0].type as string | undefined;
+    getFragment = (fragment) => {
+      return fragment;
     },
 
     preInsert = (fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
-      const firstNodeType = getFirstNodeType(fragment);
+      const firstNodeType = fragment[0].type as string | undefined;
 
       // replace the selected node type by the first block type
       if (
@@ -84,8 +84,7 @@ export const withDeserializeMD = <
 
       if (!fragment.length) return;
 
-      // FIXME: Do something to make sure it gets handled as a document fragment (see html deserializer)
-
+      fragment = getFragment(fragment);
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -30,7 +30,7 @@ export interface WithDeserializeMarkdownOptions<
   insert?: (fragment: TDescendant[]) => void;
 
   /**
-   * Function called to get a custom fragment structure.
+   * Function called to get a custom fragment root.
    * Default: fragment.
    */
   getFragment?: (fragment: TDescendant[]) => TDescendant[];


### PR DESCRIPTION
**Description**

If your ast is non-standard, you may need to override the fragment root (most likely only for ast, but for consistency adding the option for all deserializers)

**Issue**

With a non-standard ast structure, you can end up with the wrong type applied to the first node that gets pasted.

**Example**



**Context**


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
