### PR TITLE
added deserializer for ELEMENT_LIC

### DIFF
--- a/.changeset/gold-planes-dance.md
+++ b/.changeset/gold-planes-dance.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-list": patch
+---
+
+add deserializer for `ELEMENT_LIC`

--- a/packages/elements/list/src/getListDeserialize.ts
+++ b/packages/elements/list/src/getListDeserialize.ts
@@ -3,10 +3,11 @@ import {
   Deserialize,
   getSlatePluginOptions,
 } from '@udecode/slate-plugins-core';
-import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from './defaults';
+import { ELEMENT_LI, ELEMENT_LIC, ELEMENT_OL, ELEMENT_UL } from './defaults';
 
 export const getListDeserialize = (): Deserialize => (editor) => {
   const li = getSlatePluginOptions(editor, ELEMENT_LI);
+  const lic = getSlatePluginOptions(editor, ELEMENT_LIC);
   const ul = getSlatePluginOptions(editor, ELEMENT_UL);
   const ol = getSlatePluginOptions(editor, ELEMENT_OL);
 
@@ -26,6 +27,11 @@ export const getListDeserialize = (): Deserialize => (editor) => {
         type: li.type,
         rules: [{ nodeNames: 'LI' }],
         ...li.deserialize,
+      }),
+      ...getElementDeserializer({
+        type: lic.type,
+        rules: [{ nodeNames: 'LIC' }],
+        ...lic.deserialize,
       }),
     ],
   };


### PR DESCRIPTION
**Description**

Allow customization of ELEMENT_LIC deserializer, just as all other elements allow it.

**Issue**

Fixes: https://github.com/udecode/slate-plugins/issues/816

**Example**

```
createSlatePluginsComponents({
  [ELEMENT_LIC]: withProps(StyledElement, {
    as: 'span',
  }),
})
```

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`. (no tests added; couldn't find any for the list deserializers)
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [ ] The relevant examples still work: (Run examples with `yarn docs`.) (couldn't get them to run on my m1 macbook; node-sass takes forever too build when running `yarn` in  the `docs` directory)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
