### PR TITLE
Markdown deserializer should not block simple URL paste, fixes #800

### DIFF
--- a/.changeset/shiny-snakes-listen.md
+++ b/.changeset/shiny-snakes-listen.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-md-serializer": patch
+---
+
+Markdown deserializer was breaking the pasting of a simple URL into the editor. Now checks the content and if it's simply a URL, it skips the handling of the content as markdown

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -1,4 +1,8 @@
-import { isBlockAboveEmpty, setNodes } from '@udecode/slate-plugins-common';
+import {
+  isBlockAboveEmpty,
+  isUrl,
+  setNodes,
+} from '@udecode/slate-plugins-common';
 import {
   getInlineTypes,
   getSlatePluginWithOverrides,
@@ -80,6 +84,12 @@ export const withDeserializeMD = <
     const content = data.getData('text/plain');
 
     if (content) {
+      // if content is simply a URL, pass through to not break LinkPlugin
+      if (isUrl(content)) {
+        insertData(data);
+        return;
+      }
+
       let fragment = deserializeMD(editor, content);
 
       if (!fragment.length) return;


### PR DESCRIPTION
**Description**

Markdown deserializer was breaking the pasting of a simple URL into the editor. This fix checks the content and if it's simply a URL, it skips the handling of the content as markdown.

**Issue**

Fixes: #800

**Example**

See #800

**Context**

See #800

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
