### PR TITLE
deserializers: if no fragment to deserialize, call insertData and return

### DIFF
--- a/.changeset/fresh-months-serve.md
+++ b/.changeset/fresh-months-serve.md
@@ -1,0 +1,7 @@
+---
+"@udecode/slate-plugins-ast-serializer": minor
+"@udecode/slate-plugins-html-serializer": minor
+"@udecode/slate-plugins-md-serializer": minor
+---
+
+If empty fragment, eject from deserializer

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -80,6 +80,12 @@ export const withDeserializeAst = <
       const decoded = decodeURIComponent(window.atob(ast));
       let fragment = JSON.parse(decoded);
       fragment = getFragment(fragment);
+
+      if (!fragment.length) {
+        insertData(data);
+        return;
+      }
+
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -79,13 +79,13 @@ export const withDeserializeAst = <
     if (ast) {
       const decoded = decodeURIComponent(window.atob(ast));
       let fragment = JSON.parse(decoded);
-      fragment = getFragment(fragment);
 
       if (!fragment.length) {
         insertData(data);
         return;
       }
 
+      fragment = getFragment(fragment);
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -86,6 +86,12 @@ export const withDeserializeHTML = <
         element: body,
       });
       fragment = getFragment(fragment);
+
+      if (!fragment.length) {
+        insertData(data);
+        return;
+      }
+
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -85,13 +85,12 @@ export const withDeserializeHTML = <
         plugins,
         element: body,
       });
-      fragment = getFragment(fragment);
 
       if (!fragment.length) {
         insertData(data);
         return;
       }
-
+      fragment = getFragment(fragment);
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -92,13 +92,11 @@ export const withDeserializeMD = <
 
       let fragment = deserializeMD(editor, content);
 
-      fragment = getFragment(fragment);
-
       if (!fragment.length) {
         insertData(data);
         return;
       }
-
+      fragment = getFragment(fragment);
       fragment = preInsert(fragment);
 
       insert(fragment);

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -92,9 +92,13 @@ export const withDeserializeMD = <
 
       let fragment = deserializeMD(editor, content);
 
-      if (!fragment.length) return;
-
       fragment = getFragment(fragment);
+
+      if (!fragment.length) {
+        insertData(data);
+        return;
+      }
+
       fragment = preInsert(fragment);
 
       insert(fragment);


### PR DESCRIPTION
**Description**

If the fragment is empty in a deserializer, it potentially blocks the calling of the next deserializer up the tree. This change should fix that scenario

**Issue**

See description

**Example**

I don't have a good example, but the logic to simply return felt less accurate than an explicit call to insertData.

**Context**

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
