### PR TITLE
missed adding csv-serializer to slate-plugins package.json

### DIFF
--- a/.changeset/modern-kangaroos-invent.md
+++ b/.changeset/modern-kangaroos-invent.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins": patch
+---
+
+Missed adding new package for top-level package.json

--- a/packages/slate-plugins/package.json
+++ b/packages/slate-plugins/package.json
@@ -47,6 +47,7 @@
     "@udecode/slate-plugins-code-block-ui": "1.0.0-next.46",
     "@udecode/slate-plugins-common": "1.0.0-next.46",
     "@udecode/slate-plugins-core": "1.0.0-next.40",
+    "@udecode/slate-plugins-csv-serializer": "1.0.0-next.48",
     "@udecode/slate-plugins-dnd": "1.0.0-next.46",
     "@udecode/slate-plugins-find-replace": "1.0.0-next.46",
     "@udecode/slate-plugins-find-replace-ui": "1.0.0-next.46",

--- a/packages/slate-plugins/package.json
+++ b/packages/slate-plugins/package.json
@@ -47,7 +47,7 @@
     "@udecode/slate-plugins-code-block-ui": "1.0.0-next.46",
     "@udecode/slate-plugins-common": "1.0.0-next.46",
     "@udecode/slate-plugins-core": "1.0.0-next.40",
-    "@udecode/slate-plugins-csv-serializer": "1.0.0-next.48",
+    "@udecode/slate-plugins-csv-serializer": "1.0.0-next.49",
     "@udecode/slate-plugins-dnd": "1.0.0-next.46",
     "@udecode/slate-plugins-find-replace": "1.0.0-next.46",
     "@udecode/slate-plugins-find-replace-ui": "1.0.0-next.46",


### PR DESCRIPTION
**Description**

Missed a dependency for the new csv-serializer in the top-level slate-plugins

**Issue**

Missed a dependency for the new csv-serializer in the top-level slate-plugins

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
