### PR TITLE
core-prevent-default

### DIFF
--- a/.changeset/fair-schools-appear.md
+++ b/.changeset/fair-schools-appear.md
@@ -1,0 +1,8 @@
+---
+"@udecode/slate-plugins-core": major
+---
+
+Before, the handlers had to return `false` to prevent the next handlers to be called.
+Now, we reuse `isEventHandled` internally used by `slate@0.65.0` which has the opposite behavior: a handler has to return `true` to stop the pipeline.
+Additionally, the pipeline stops if at any moment `event.isDefaultPrevented()` or `event.isPropagationStopped()` returns `true`, except if the handler returns `false`.
+See the updated docs in "Creating Plugins".

--- a/docs/docs/guides/creating-plugins.mdx
+++ b/docs/docs/guides/creating-plugins.mdx
@@ -137,9 +137,40 @@ export const createReactPlugin = {
 
 ### Handlers
 
-- `SlatePlugins` extends and pipes the following handlers.
 - Function called whenever the corresponding event occurs in the editor.
-- To prevent the next handler from running, return `false`.
+- There is 3 places where a handler (e.g. `onClick`) can be defined (called in this order):
+  - in `SlatePlugin` (plugin) 
+  - in `SlatePlugins` (props)
+  - in `Slate` (internal handler)
+- Event handlers can return a boolean flag to specify whether the event can be treated as being handled.
+- If the event is handled, the next handlers will not be called.
+
+```tsx
+const onClick = (event) => {
+  // Implement custom event logic...
+
+  // When no value is returned, the next handlers will be executed when
+  // neither isDefaultPrevented nor isPropagationStopped was set on the event
+};
+
+const onDrop = (event) => {
+  // Implement custom event logic...
+
+  // No matter the state of the event, treat it as being handled by returning
+  // true here, the next handlers will be skipped
+  return true;
+};
+
+const onDragStart = (event) => {
+  // Implement custom event logic...
+
+  // No matter the status of the event, treat event as *not* being handled by
+  // returning false, the next handlers will be executed afterward
+  return false;
+};
+```
+
+`SlatePlugins` extends the following handlers:
 
 ```tsx
 type ReturnType = boolean | void;

--- a/packages/core/src/hooks/useSlatePlugins/useSlateProps.ts
+++ b/packages/core/src/hooks/useSlatePlugins/useSlateProps.ts
@@ -25,9 +25,13 @@ export const useSlateProps = ({
       key: editor?.key,
       editor,
       onChange: (newValue: TNode[]) => {
-        editor && pipeOnChange(editor, plugins)(newValue);
+        if (!editor) return;
 
-        _onChange?.(newValue);
+        const eventIsHandled = pipeOnChange(editor, plugins)(newValue);
+
+        if (!eventIsHandled) {
+          _onChange?.(newValue);
+        }
 
         setValue(newValue);
       },

--- a/packages/core/src/types/SlatePlugin/DOMHandlers.ts
+++ b/packages/core/src/types/SlatePlugin/DOMHandlers.ts
@@ -16,7 +16,9 @@ import {
 } from 'react';
 import { SPEditor } from '../SPEditor';
 
-type ReturnType = boolean | void;
+export type DOMHandlerReturnType = boolean | void;
+
+type ReturnType = DOMHandlerReturnType;
 
 export type DOMHandler<
   K extends keyof DOMHandlers,

--- a/packages/core/src/types/SlatePlugin/OnChange.ts
+++ b/packages/core/src/types/SlatePlugin/OnChange.ts
@@ -1,5 +1,6 @@
 import { SPEditor } from '../SPEditor';
 import { TNode } from '../TNode';
+import { DOMHandlerReturnType } from './DOMHandlers';
 
 /**
  * Function called whenever a change occurs in the editor.
@@ -8,4 +9,4 @@ import { TNode } from '../TNode';
  */
 export type OnChange<T extends SPEditor = SPEditor> = (
   editor: T
-) => (value: TNode[]) => boolean | void;
+) => (value: TNode[]) => DOMHandlerReturnType;

--- a/packages/core/src/utils/pipeOnChange.ts
+++ b/packages/core/src/utils/pipeOnChange.ts
@@ -11,6 +11,19 @@ export const pipeOnChange = (
   );
 
   return (nodes) => {
-    onChanges.some((onChange) => onChange(nodes) === false);
+    return onChanges.some((handler) => {
+      if (!handler) {
+        return false;
+      }
+      // The custom event handler may return a boolean to specify whether the event
+      // shall be treated as being handled or not.
+      const shouldTreatEventAsHandled = handler(nodes);
+
+      if (shouldTreatEventAsHandled != null) {
+        return shouldTreatEventAsHandled;
+      }
+
+      return false;
+    });
   };
 };


### PR DESCRIPTION
**Description**

Before, the handlers had to return `false` to prevent the next handlers to be called.
Now, we reuse `isEventHandled` internally used by `slate@0.65.0` which has the opposite behavior: a handler has to return `true` to stop the pipeline.
Additionally, the pipeline stops if at any moment `event.isDefaultPrevented()` or `event.isPropagationStopped()` returns `true`, except if the handler returns `false`.

See the updated docs in "Creating Plugins".

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->




<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
