### PR TITLE
handlers

### DIFF
--- a/.changeset/giant-kings-hug.md
+++ b/.changeset/giant-kings-hug.md
@@ -1,0 +1,6 @@
+---
+"@udecode/slate-plugins-core": patch
+---
+
+Sometimes we want to preventDefault without stopping the handler pipeline, so we remove this check.
+In summary, to stop the pipeline, a handler has to return `true` or run `event.stopPropagation()`

--- a/docs/docs/guides/creating-plugins.mdx
+++ b/docs/docs/guides/creating-plugins.mdx
@@ -150,7 +150,7 @@ const onClick = (event) => {
   // Implement custom event logic...
 
   // When no value is returned, the next handlers will be executed when
-  // neither isDefaultPrevented nor isPropagationStopped was set on the event
+  // isPropagationStopped was not set on the event
 };
 
 const onDrop = (event) => {

--- a/packages/core/src/utils/pipeHandler.ts
+++ b/packages/core/src/utils/pipeHandler.ts
@@ -27,7 +27,7 @@ export const isEventHandled = <
     return shouldTreatEventAsHandled;
   }
 
-  return event.isDefaultPrevented() || event.isPropagationStopped();
+  return event.isPropagationStopped();
 };
 
 /**


### PR DESCRIPTION
**Description**

Sometimes we want to preventDefault without stopping the handlers pipeline, so we remove this check.
To stop the pipeline, a handler has to return `true` or run `event.stopPropagation()`

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->




<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
