### PR TITLE
List normalize node entry call signature

### DIFF
--- a/.changeset/heavy-poems-cheat.md
+++ b/.changeset/heavy-poems-cheat.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-list": patch
+---
+
+fix call signature for list normalizeNode

--- a/packages/elements/list/src/withList.ts
+++ b/packages/elements/list/src/withList.ts
@@ -28,7 +28,8 @@ export const withList = ({
     deleteFragment();
   };
 
-  editor.normalizeNode = getListNormalizer(editor, { validLiChildrenTypes });
+  editor.normalizeNode = (entry) =>
+    getListNormalizer(editor, { validLiChildrenTypes });
 
   return editor;
 };


### PR DESCRIPTION
**Description**

Fix the call signature for the list plugin normalizeNode to include an entry

**Issue**

Fixes: In some cases the ast for a list was getting created without a parent ul/ol element.

**Example**

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
