### PR TITLE
Insert list was breaking due to premature normalization

### DIFF
--- a/.changeset/heavy-poems-cheat.md
+++ b/.changeset/heavy-poems-cheat.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-list": patch
+---
+
+fix call signature for list normalizeNode

--- a/.changeset/heavy-poems-cheat.md
+++ b/.changeset/heavy-poems-cheat.md
@@ -2,4 +2,4 @@
 "@udecode/slate-plugins-list": patch
 ---
 
-fix call signature for list normalizeNode
+wrap toggleNode inside a withoutNormalizing call to prevent errors when inserting new lists

--- a/packages/elements/list/src/transforms/toggleList.ts
+++ b/packages/elements/list/src/transforms/toggleList.ts
@@ -10,40 +10,43 @@ import {
   SPEditor,
   TElement,
 } from '@udecode/slate-plugins-core';
+import { Editor } from 'slate';
 import { ELEMENT_LI, ELEMENT_LIC } from '../defaults';
 import { unwrapList } from './unwrapList';
 
 export const toggleList = (editor: SPEditor, { type }: { type: string }) => {
   if (!editor.selection) return;
 
-  const isActive = someNode(editor, { match: { type } });
+  Editor.withoutNormalizing(editor, () => {
+    const isActive = someNode(editor, { match: { type } });
 
-  unwrapList(editor);
+    unwrapList(editor);
 
-  setNodes<TElement>(editor, {
-    type: getSlatePluginType(editor, ELEMENT_DEFAULT),
-  });
+    setNodes<TElement>(editor, {
+      type: getSlatePluginType(editor, ELEMENT_DEFAULT),
+    });
 
-  if (!isActive) {
-    const list = { type, children: [] };
-    wrapNodes(editor, list);
+    if (!isActive) {
+      const list = { type, children: [] };
+      wrapNodes(editor, list);
 
-    const nodes = [
-      ...getNodes(editor, {
-        match: { type: getSlatePluginType(editor, ELEMENT_DEFAULT) },
-      }),
-    ];
-    setNodes(editor, { type: getSlatePluginType(editor, ELEMENT_LIC) });
+      const nodes = [
+        ...getNodes(editor, {
+          match: { type: getSlatePluginType(editor, ELEMENT_DEFAULT) },
+        }),
+      ];
+      setNodes(editor, { type: getSlatePluginType(editor, ELEMENT_LIC) });
 
-    const listItem = {
-      type: getSlatePluginType(editor, ELEMENT_LI),
-      children: [],
-    };
+      const listItem = {
+        type: getSlatePluginType(editor, ELEMENT_LI),
+        children: [],
+      };
 
-    for (const [, path] of nodes) {
-      wrapNodes(editor, listItem, {
-        at: path,
-      });
+      for (const [, path] of nodes) {
+        wrapNodes(editor, listItem, {
+          at: path,
+        });
+      }
     }
-  }
+  });
 };

--- a/packages/elements/list/src/withList.ts
+++ b/packages/elements/list/src/withList.ts
@@ -28,7 +28,8 @@ export const withList = ({
     deleteFragment();
   };
 
-  editor.normalizeNode = getListNormalizer(editor, { validLiChildrenTypes });
+  editor.normalizeNode = (entry) =>
+    getListNormalizer(editor, { validLiChildrenTypes });
 
   return editor;
 };

--- a/packages/elements/list/src/withList.ts
+++ b/packages/elements/list/src/withList.ts
@@ -28,8 +28,7 @@ export const withList = ({
     deleteFragment();
   };
 
-  editor.normalizeNode = (entry) =>
-    getListNormalizer(editor, { validLiChildrenTypes });
+  editor.normalizeNode = getListNormalizer(editor, { validLiChildrenTypes });
 
   return editor;
 };


### PR DESCRIPTION
**Description**

The recent normalization update at https://github.com/udecode/slate-plugins/blob/main/packages/elements/list/src/normalizers/getListNormalizer.ts#L37 was causing the ul or ol to get removed before the li gets added to the tree. This change wraps the contents of toggleList in a withoutNormalizing block to prevent normalization from kicking in before the list item gets inserted.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes:  New lists can now get inserted again.

**Example**

See how the order was incorrect:

![image (3)](https://user-images.githubusercontent.com/97291/126348025-030aa4e6-0168-4650-9512-63fc237d5a83.png)

The playground would throw an error when attempting to insert a new list.

<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
