### PR TITLE
Fix paste list into a list normalization errors

### DIFF
--- a/.changeset/few-turkeys-hunt.md
+++ b/.changeset/few-turkeys-hunt.md
@@ -1,0 +1,8 @@
+---
+"@udecode/slate-plugins-ast-serializer": patch
+"@udecode/slate-plugins-csv-serializer": patch
+"@udecode/slate-plugins-html-serializer": patch
+"@udecode/slate-plugins-md-serializer": patch
+---
+
+wrap paste deserialization in withoutNormalization block to prevent paste errors

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -8,7 +8,7 @@ import {
   TElement,
   WithOverride,
 } from '@udecode/slate-plugins-core';
-import { Transforms } from 'slate';
+import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 
 export interface WithDeserializeAstOptions<
@@ -84,11 +84,12 @@ export const withDeserializeAst = <
         insertData(data);
         return;
       }
+      Editor.withoutNormalizing(editor, () => {
+        fragment = getFragment(fragment);
+        fragment = preInsert(fragment);
 
-      fragment = getFragment(fragment);
-      fragment = preInsert(fragment);
-
-      insert(fragment);
+        insert(fragment);
+      });
       return;
     }
     insertData(data);

--- a/packages/serializers/csv-deserializer/src/deserializer/createDeserializeCSVPlugin.ts
+++ b/packages/serializers/csv-deserializer/src/deserializer/createDeserializeCSVPlugin.ts
@@ -8,7 +8,7 @@ import {
   TElement,
   WithOverride,
 } from '@udecode/slate-plugins-core';
-import { Transforms } from 'slate';
+import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { deserializeCSV } from './utils';
 
@@ -53,7 +53,7 @@ export const withDeserializeCSV = <
       return fragment;
     },
 
-    preInsert = (fragment: TElement[]) => {
+    preInsert = (fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
       const firstNodeType = fragment[0].type as string | undefined;
@@ -84,14 +84,14 @@ export const withDeserializeCSV = <
         insertData(data);
         return;
       }
+      Editor.withoutNormalizing(editor, () => {
+        fragment = getFragment(fragment as TElement[]);
+        fragment = preInsert(fragment);
 
-      fragment = getFragment(fragment);
-      fragment = preInsert(fragment);
-
-      insert(fragment);
+        insert(fragment);
+      });
       return;
     }
-
     insertData(data);
   };
 

--- a/packages/serializers/csv-deserializer/src/deserializer/utils/deserializeCSV.ts
+++ b/packages/serializers/csv-deserializer/src/deserializer/utils/deserializeCSV.ts
@@ -2,6 +2,7 @@ import { ELEMENT_DEFAULT } from '@udecode/slate-plugins-common';
 import {
   getSlatePluginType,
   SPEditor,
+  TDescendant,
   TElement,
   TNode,
 } from '@udecode/slate-plugins-core';
@@ -17,7 +18,7 @@ export const deserializeCSV = <T extends SPEditor = SPEditor>(
   editor: T,
   content: string,
   header = false
-) => {
+): TDescendant[] | undefined => {
   // Verify it's a csv string
   const testCsv = parse(content, { preview: 2 });
 

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -8,7 +8,7 @@ import {
   TElement,
   WithOverride,
 } from '@udecode/slate-plugins-core';
-import { Transforms } from 'slate';
+import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { deserializeHTMLToDocumentFragment } from './utils/deserializeHTMLToDocumentFragment';
 
@@ -90,10 +90,12 @@ export const withDeserializeHTML = <
         insertData(data);
         return;
       }
-      fragment = getFragment(fragment);
-      fragment = preInsert(fragment);
+      Editor.withoutNormalizing(editor, () => {
+        fragment = getFragment(fragment);
+        fragment = preInsert(fragment);
 
-      insert(fragment);
+        insert(fragment);
+      });
       return;
     }
 

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -12,7 +12,7 @@ import {
   TElement,
   WithOverride,
 } from '@udecode/slate-plugins-core';
-import { Transforms } from 'slate';
+import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { deserializeMD } from './utils/deserializeMD';
 
@@ -96,10 +96,12 @@ export const withDeserializeMD = <
         insertData(data);
         return;
       }
-      fragment = getFragment(fragment);
-      fragment = preInsert(fragment);
+      Editor.withoutNormalizing(editor, () => {
+        fragment = getFragment(fragment);
+        fragment = preInsert(fragment);
 
-      insert(fragment);
+        insert(fragment);
+      });
       return;
     }
 


### PR DESCRIPTION
**Description**

When pasting from a slate-plugins list into another list, it was often causing normalization errors like this:

```
Uncaught Error: 
            Could not completely normalize the editor after 966 iterations! This is usually due to incorrect normalization logic that leaves a node in an invalid state.
    normalize https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    withoutNormalizing https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    normalize https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    withoutNormalizing https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    insertFragment https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    l https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    insertData https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    insertData https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    b https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
5009.f5f344b9.js:2:4091211
    normalize https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    withoutNormalizing https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    normalize https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    withoutNormalizing https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    insertFragment https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    l https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    insertData https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    insertData https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
    b https://slate-plugins.udecode.io/assets/js/5009.f5f344b9.js:2
```

I have wrapped the paste deserialization logic in Editor.withoutNormalizing calls which seems to prevent crashing errors.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: Paste from a slate-plugins list into another list (and perhaps other non-trivial paste operations) should no longer crash the editors.

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
