### PR TITLE
Deserializer insert override

### DIFF
--- a/.changeset/little-horses-sip.md
+++ b/.changeset/little-horses-sip.md
@@ -1,0 +1,8 @@
+---
+"@udecode/slate-plugins-ast-serializer": minor
+"@udecode/slate-plugins-csv-serializer": minor
+"@udecode/slate-plugins-html-serializer": minor
+"@udecode/slate-plugins-md-serializer": minor
+---
+
+Refactor insert for deserializers

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -17,23 +17,18 @@ export interface WithDeserializeAstOptions<
   plugins?: SlatePlugin<T>[];
 
   /**
-   * Function called before inserting the deserialized html.
+   * Function called to insert the cleaned up ast.
    * Default: if the block above is empty and the first fragment node type is not inline,
    * set the selected node type to the first fragment node type.
+   * Then call Transforms.setNodes.
    */
-  preInsert?: (fragment: TDescendant[]) => TDescendant[];
-
-  /**
-   * Function called to insert the cleaned up ast.
-   * Default: Transforms.setNodes.
-   */
-  insert?: (fragment: TDescendant[]) => void;
+  insert?: (editor: T, fragment: TDescendant[]) => TDescendant[];
 
   /**
    * Function called to get a custom fragment root.
    * Default: fragment.
    */
-  getFragment?: (fragment: TDescendant[]) => TDescendant[];
+  getFragment?: (editor: T, fragment: TDescendant[]) => TDescendant[];
 }
 
 /**
@@ -49,28 +44,28 @@ export const withDeserializeAst = <
   const { insertData } = editor;
 
   const {
-    getFragment = (fragment) => {
+    getFragment = (_editor, fragment) => {
       return fragment;
     },
 
-    preInsert = (fragment) => {
-      const inlineTypes = getInlineTypes(editor, plugins);
+    insert = (_editor, fragment) => {
+      const inlineTypes = getInlineTypes(_editor, plugins);
 
       const firstNodeType = fragment[0].type as string | undefined;
 
       // replace the selected node type by the first block type
       if (
-        isBlockAboveEmpty(editor) &&
+        isBlockAboveEmpty(_editor) &&
         firstNodeType &&
-        !inlineTypes.includes(firstNodeType)
+        !inlineTypes.includes(firstNodeType) &&
+        fragment[0].type
       ) {
-        setNodes<TElement>(editor, { type: firstNodeType });
+        setNodes<TElement>(_editor, { type: firstNodeType });
       }
 
+      Transforms.insertFragment(_editor, fragment);
       return fragment;
     },
-
-    insert = (fragment) => Transforms.insertFragment(editor, fragment),
   } = options;
 
   editor.insertData = (data: DataTransfer) => {
@@ -85,10 +80,8 @@ export const withDeserializeAst = <
         return;
       }
       Editor.withoutNormalizing(editor, () => {
-        fragment = getFragment(fragment);
-        fragment = preInsert(fragment);
-
-        insert(fragment);
+        fragment = getFragment(editor, fragment);
+        fragment = insert(editor, fragment as TElement[]);
       });
       return;
     }

--- a/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
+++ b/packages/serializers/ast-serializer/src/deserializer/createDeserializeAstPlugin.ts
@@ -22,7 +22,7 @@ export interface WithDeserializeAstOptions<
    * set the selected node type to the first fragment node type.
    * Then call Transforms.setNodes.
    */
-  insert?: (editor: T, fragment: TDescendant[]) => TDescendant[];
+  insert?: (editor: T, fragment: TDescendant[]) => void;
 
   /**
    * Function called to get a custom fragment root.
@@ -64,7 +64,6 @@ export const withDeserializeAst = <
       }
 
       Transforms.insertFragment(_editor, fragment);
-      return fragment;
     },
   } = options;
 
@@ -81,7 +80,7 @@ export const withDeserializeAst = <
       }
       Editor.withoutNormalizing(editor, () => {
         fragment = getFragment(editor, fragment);
-        fragment = insert(editor, fragment as TElement[]);
+        insert(editor, fragment as TElement[]);
       });
       return;
     }

--- a/packages/serializers/csv-deserializer/src/deserializer/createDeserializeCSVPlugin.ts
+++ b/packages/serializers/csv-deserializer/src/deserializer/createDeserializeCSVPlugin.ts
@@ -22,7 +22,7 @@ export interface WithDeserializeCSVOptions<
    * set the selected node type to the first fragment node type.
    * Then call Transforms.insertFragment.
    */
-  insert?: (editor: T, fragment: TDescendant[]) => TDescendant[];
+  insert?: (editor: T, fragment: TDescendant[]) => void;
 
   /**
    * Function called to get a custom fragment root.
@@ -64,8 +64,6 @@ export const withDeserializeCSV = <
       }
 
       Transforms.insertFragment(_editor, fragment);
-
-      return fragment;
     },
   } = options;
 
@@ -81,7 +79,7 @@ export const withDeserializeCSV = <
       }
       Editor.withoutNormalizing(editor, () => {
         fragment = getFragment(editor, fragment as TElement[]);
-        fragment = insert(editor, fragment);
+        insert(editor, fragment);
       });
       return;
     }

--- a/packages/serializers/csv-deserializer/src/deserializer/createDeserializeCSVPlugin.ts
+++ b/packages/serializers/csv-deserializer/src/deserializer/createDeserializeCSVPlugin.ts
@@ -17,23 +17,18 @@ export interface WithDeserializeCSVOptions<
 > {
   plugins?: SlatePlugin<T>[];
   /**
-   * Function called before inserting the deserialized csv.
+   * Function called to cleanup and insert the deserialized csv.
    * Default: if the block above is empty and the first fragment node type is not inline,
    * set the selected node type to the first fragment node type.
+   * Then call Transforms.insertFragment.
    */
-  preInsert?: (fragment: TDescendant[]) => TDescendant[];
-
-  /**
-   * Function called to insert the deserialized csv.
-   * Default: Transforms.insertFragment.
-   */
-  insert?: (fragment: TDescendant[]) => void;
+  insert?: (editor: T, fragment: TDescendant[]) => TDescendant[];
 
   /**
    * Function called to get a custom fragment root.
    * Default: fragment.
    */
-  getFragment?: (fragment: TDescendant[]) => TDescendant[];
+  getFragment?: (editor: T, fragment: TDescendant[]) => TDescendant[];
 }
 
 /**
@@ -49,29 +44,29 @@ export const withDeserializeCSV = <
   const { insertData } = editor;
 
   const {
-    getFragment = (fragment) => {
+    getFragment = (_editor, fragment) => {
       return fragment;
     },
 
-    preInsert = (fragment) => {
-      const inlineTypes = getInlineTypes(editor, plugins);
+    insert = (_editor, fragment) => {
+      const inlineTypes = getInlineTypes(_editor, plugins);
 
       const firstNodeType = fragment[0].type as string | undefined;
 
       // replace the selected node type by the first block type
       if (
-        isBlockAboveEmpty(editor) &&
+        isBlockAboveEmpty(_editor) &&
         firstNodeType &&
         !inlineTypes.includes(firstNodeType) &&
         fragment[0].type
       ) {
-        setNodes<TElement>(editor, { type: firstNodeType });
+        setNodes<TElement>(_editor, { type: firstNodeType });
       }
+
+      Transforms.insertFragment(_editor, fragment);
 
       return fragment;
     },
-
-    insert = (fragment) => Transforms.insertFragment(editor, fragment),
   } = options;
 
   editor.insertData = (data) => {
@@ -85,10 +80,8 @@ export const withDeserializeCSV = <
         return;
       }
       Editor.withoutNormalizing(editor, () => {
-        fragment = getFragment(fragment as TElement[]);
-        fragment = preInsert(fragment);
-
-        insert(fragment);
+        fragment = getFragment(editor, fragment as TElement[]);
+        fragment = insert(editor, fragment);
       });
       return;
     }

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -23,7 +23,7 @@ export interface WithDeserializeHTMLOptions<
    * set the selected node type to the first fragment node type.
    * Then call Transforms.insertFragment.
    */
-  insert?: (editor: T, fragment: TDescendant[]) => TDescendant[];
+  insert?: (editor: T, fragment: TDescendant[]) => void;
 
   /**
    * Function called to get a custom fragment root.
@@ -63,7 +63,6 @@ export const withDeserializeHTML = <
         setNodes<TElement>(_editor, { type: firstNodeType });
       }
       Transforms.insertFragment(editor, fragment);
-      return fragment;
     },
   } = options;
 
@@ -84,7 +83,7 @@ export const withDeserializeHTML = <
       }
       Editor.withoutNormalizing(editor, () => {
         fragment = getFragment(editor, fragment);
-        fragment = insert(editor, fragment);
+        insert(editor, fragment);
       });
       return;
     }

--- a/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
+++ b/packages/serializers/html-serializer/src/deserializer/createDeserializeHTMLPlugin.ts
@@ -18,23 +18,18 @@ export interface WithDeserializeHTMLOptions<
   plugins?: SlatePlugin<T>[];
 
   /**
-   * Function called before inserting the deserialized html.
+   * Function called to cleanup and insert the deserialized html.
    * Default: if the block above is empty and the first fragment node type is not inline,
    * set the selected node type to the first fragment node type.
+   * Then call Transforms.insertFragment.
    */
-  preInsert?: (fragment: TDescendant[]) => TDescendant[];
-
-  /**
-   * Function called to insert the deserialized html.
-   * Default: Transforms.insertFragment.
-   */
-  insert?: (fragment: TDescendant[]) => void;
+  insert?: (editor: T, fragment: TDescendant[]) => TDescendant[];
 
   /**
    * Function called to get a custom fragment root.
    * Default: fragment.
    */
-  getFragment?: (fragment: TDescendant[]) => TDescendant[];
+  getFragment?: (editor: T, fragment: TDescendant[]) => TDescendant[];
 }
 
 /**
@@ -49,29 +44,26 @@ export const withDeserializeHTML = <
   const { insertData } = editor;
 
   const {
-    getFragment = (fragment) => {
+    getFragment = (_editor, fragment) => {
       return fragment;
     },
 
-    preInsert = (fragment) => {
+    insert = (_editor, fragment) => {
       const inlineTypes = getInlineTypes(editor, plugins);
 
       const firstNodeType = fragment[0].type as string | undefined;
 
       // replace the selected node type by the first block type
       if (
-        isBlockAboveEmpty(editor) &&
+        isBlockAboveEmpty(_editor) &&
         firstNodeType &&
-        !inlineTypes.includes(firstNodeType)
+        !inlineTypes.includes(firstNodeType) &&
+        fragment[0].type
       ) {
-        setNodes<TElement>(editor, { type: firstNodeType });
+        setNodes<TElement>(_editor, { type: firstNodeType });
       }
-
-      return fragment;
-    },
-
-    insert = (fragment) => {
       Transforms.insertFragment(editor, fragment);
+      return fragment;
     },
   } = options;
 
@@ -91,10 +83,8 @@ export const withDeserializeHTML = <
         return;
       }
       Editor.withoutNormalizing(editor, () => {
-        fragment = getFragment(fragment);
-        fragment = preInsert(fragment);
-
-        insert(fragment);
+        fragment = getFragment(editor, fragment);
+        fragment = insert(editor, fragment);
       });
       return;
     }

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -26,7 +26,7 @@ export interface WithDeserializeMarkdownOptions<
    * set the selected node type to the first fragment node type.
    * Then call Transforms.insertFragment.
    */
-  insert?: (editor: T, fragment: TDescendant[]) => TDescendant[];
+  insert?: (editor: T, fragment: TDescendant[]) => void;
 
   /**
    * Function called to get a custom fragment root.
@@ -67,8 +67,6 @@ export const withDeserializeMD = <
         setNodes<TElement>(_editor, { type: firstNodeType });
       }
       Transforms.insertFragment(_editor, fragment);
-
-      return fragment;
     },
   } = options;
 
@@ -90,7 +88,7 @@ export const withDeserializeMD = <
       }
       Editor.withoutNormalizing(editor, () => {
         fragment = getFragment(editor, fragment);
-        fragment = insert(editor, fragment);
+        insert(editor, fragment);
       });
       return;
     }


### PR DESCRIPTION
**Description**

The deserializers for handling pasted comments were not easy to override as there was no reference to the editor easily available. Also combined preInsert and insert for simplicity as there was not much utility in having them separate.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: 

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
