### PR TITLE
Fix empty style in deserialization

### DIFF
--- a/.changeset/long-seahorses-check.md
+++ b/.changeset/long-seahorses-check.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-common": patch
+---
+
+HTML deserializer with `'*'` style rule was inserting empty fields (e.g. color) on each paste. Fixed by not allowing empty styles to be deserialized.

--- a/packages/common/src/utils/getNodeDeserializer.ts
+++ b/packages/common/src/utils/getNodeDeserializer.ts
@@ -24,6 +24,7 @@ export const getNodeDeserializer = ({
         type,
         withoutChildren,
         deserialize: (el) => {
+          // Ignore if el nodeName is not included in rule nodeNames (except *).
           if (
             nodeNames.length &&
             !nodeNames.includes(el.nodeName) &&
@@ -31,13 +32,18 @@ export const getNodeDeserializer = ({
           )
             return;
 
+          // Ignore if the rule className is not in el class list.
           if (className && !el.classList.contains(className)) return;
 
           if (style) {
             for (const [key, value] of Object.entries(style)) {
               const values = castArray<string>(value);
 
+              // Ignore if el style value is not included in rule style values (except *)
               if (!values.includes(el.style[key]) && value !== '*') return;
+
+              // Ignore if el style value is falsy (for value *)
+              if (value === '*' && !el.style[key]) return;
             }
           }
 


### PR DESCRIPTION
**Description**

Do not deserialize empty styles

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: #863 





<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
